### PR TITLE
Change Dependabot PR target branch to `develop`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: "develop"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/docs" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
## Description:

This PR updates the `dependabot.yml` configuration to change the default target branch for Dependabot pull requests from `main` to `develop`. 

## Changes:
- Set the `target-branch` in `.github/dependabot.yml` to `develop`.
  
This will ensure that all future dependency updates will be merged into the `develop` branch instead of the `main` branch, aligning with our development workflow.
