### PR TITLE
Refactor: Rename `BlockType` to `Block` and `Block` to `BlockResponse`

### DIFF
--- a/src/block/audio.rs
+++ b/src/block/audio.rs
@@ -9,8 +9,8 @@ pub struct AudioBlock {
 }
 
 impl AudioBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Audio(self)
+    pub fn build(self) -> super::Block {
+        super::Block::Audio(self)
     }
 
     pub fn new() -> Self {

--- a/src/block/bookmark.rs
+++ b/src/block/bookmark.rs
@@ -14,8 +14,8 @@ pub struct BookmarkBlock {
 }
 
 impl BookmarkBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Bookmark { bookmark: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Bookmark { bookmark: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/bulleted_list_item.rs
+++ b/src/block/bulleted_list_item.rs
@@ -17,12 +17,12 @@ pub struct BulletedListItemBlock {
     /// It can only be specified when making a block creation request.
     /// If you need to retrieve the child blocks, you will have to send a request to this block again.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<super::BlockType>>,
+    pub children: Option<Vec<super::Block>>,
 }
 
 impl BulletedListItemBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::BulletedListItem {
+    pub fn build(self) -> super::Block {
+        super::Block::BulletedListItem {
             bulleted_list_item: self,
         }
     }
@@ -36,7 +36,7 @@ impl BulletedListItemBlock {
         self
     }
 
-    pub fn children(mut self, children: Vec<super::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<super::Block>) -> Self {
         self.children = Some(children);
         self
     }

--- a/src/block/callout.rs
+++ b/src/block/callout.rs
@@ -19,8 +19,8 @@ pub struct CalloutBlock {
 }
 
 impl CalloutBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Callout { callout: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Callout { callout: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/code.rs
+++ b/src/block/code.rs
@@ -17,8 +17,8 @@ pub struct CodeBlock {
 }
 
 impl CodeBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Code { code: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Code { code: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/column.rs
+++ b/src/block/column.rs
@@ -5,12 +5,12 @@ pub struct ColumnBlock {
     /// It can only be specified when making a block creation request.
     /// If you need to retrieve the child blocks, you will have to send a request to this block again.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<super::BlockType>>,
+    pub children: Option<Vec<super::Block>>,
 }
 
 impl ColumnBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Column { column: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Column { column: self }
     }
 
     pub fn new() -> Self {
@@ -19,7 +19,7 @@ impl ColumnBlock {
         }
     }
 
-    pub fn children(mut self, children: Vec<super::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<super::Block>) -> Self {
         self.children = Some(children);
         self
     }

--- a/src/block/column_list.rs
+++ b/src/block/column_list.rs
@@ -6,12 +6,12 @@ pub struct ColumnListBlock {
     /// It can only be specified when making a block creation request.
     /// If you need to retrieve the child blocks, you will have to send a request to this block again.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<super::BlockType>>,
+    pub children: Option<Vec<super::Block>>,
 }
 
 impl ColumnListBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::ColumnList { column_list: self }
+    pub fn build(self) -> super::Block {
+        super::Block::ColumnList { column_list: self }
     }
 
     pub fn new() -> Self {
@@ -21,7 +21,7 @@ impl ColumnListBlock {
     }
 
     /// Only `column` can be specified.
-    pub fn children(mut self, children: Vec<super::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<super::Block>) -> Self {
         self.children = Some(children);
         self
     }

--- a/src/block/embed.rs
+++ b/src/block/embed.rs
@@ -11,8 +11,8 @@ pub struct EmbedBlock {
 }
 
 impl EmbedBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Embed { embed: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Embed { embed: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/equation.rs
+++ b/src/block/equation.rs
@@ -12,8 +12,8 @@ pub struct EquationBlock {
 }
 
 impl EquationBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Equation { equation: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Equation { equation: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/file.rs
+++ b/src/block/file.rs
@@ -9,8 +9,8 @@ pub struct FileBlock {
 }
 
 impl FileBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::File(self)
+    pub fn build(self) -> super::Block {
+        super::Block::File(self)
     }
 
     pub fn new() -> Self {

--- a/src/block/heading.rs
+++ b/src/block/heading.rs
@@ -23,20 +23,20 @@ pub struct HeadingBlock {
     /// It can only be specified when making a block creation request.
     /// If you need to retrieve the child blocks, you will have to send a request to this block again.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<super::BlockType>>,
+    pub children: Option<Vec<super::Block>>,
 }
 
 impl HeadingBlock {
-    pub fn build_heading_1(self) -> super::BlockType {
-        super::BlockType::Heading1 { heading_1: self }
+    pub fn build_heading_1(self) -> super::Block {
+        super::Block::Heading1 { heading_1: self }
     }
 
-    pub fn build_heading_2(self) -> super::BlockType {
-        super::BlockType::Heading2 { heading_2: self }
+    pub fn build_heading_2(self) -> super::Block {
+        super::Block::Heading2 { heading_2: self }
     }
 
-    pub fn build_heading_3(self) -> super::BlockType {
-        super::BlockType::Heading3 { heading_3: self }
+    pub fn build_heading_3(self) -> super::Block {
+        super::Block::Heading3 { heading_3: self }
     }
 
     pub fn new() -> Self {
@@ -48,7 +48,7 @@ impl HeadingBlock {
         self
     }
 
-    pub fn children(mut self, children: Vec<super::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<super::Block>) -> Self {
         self.children = Some(children);
         self
     }

--- a/src/block/image.rs
+++ b/src/block/image.rs
@@ -9,8 +9,8 @@ pub struct ImageBlock {
 }
 
 impl ImageBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Image(self)
+    pub fn build(self) -> super::Block {
+        super::Block::Image(self)
     }
 
     pub fn new() -> Self {

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -59,7 +59,7 @@ pub mod video;
 /// }
 /// ```
 #[derive(Deserialize, Serialize, Debug)]
-pub struct Block {
+pub struct BlockResponse {
     pub object: String,
 
     pub id: String,
@@ -81,13 +81,13 @@ pub struct Block {
     pub in_trash: bool,
 
     #[serde(flatten)]
-    pub details: BlockType,
+    pub details: Block,
 }
 
 /// <https://developers.notion.com/reference/block#block-type-objects>
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum BlockType {
+pub enum Block {
     Audio(audio::AudioBlock),
     Bookmark {
         bookmark: bookmark::BookmarkBlock,
@@ -174,7 +174,7 @@ pub enum BlockType {
     Unknown(serde_json::Value),
 }
 
-impl BlockType {
+impl Block {
     // AudioBlock
 
     pub fn new_audio() -> audio::AudioBlock {
@@ -208,7 +208,7 @@ impl BlockType {
     }
 
     pub fn new_bulleted_list_item_with_children(
-        children: Vec<BlockType>,
+        children: Vec<Block>,
     ) -> bulleted_list_item::BulletedListItemBlock {
         bulleted_list_item::BulletedListItemBlock::new().children(children)
     }
@@ -243,8 +243,8 @@ impl BlockType {
 
     // BreadcrumbBlock
 
-    pub fn build_breadcrumb() -> BlockType {
-        BlockType::Breadcrumb {
+    pub fn build_breadcrumb() -> Block {
+        Block::Breadcrumb {
             breadcrumb: std::collections::HashMap::new(),
         }
     }
@@ -285,14 +285,14 @@ impl BlockType {
         column::ColumnBlock::new()
     }
 
-    pub fn new_column_with_children(children: Vec<BlockType>) -> column::ColumnBlock {
+    pub fn new_column_with_children(children: Vec<Block>) -> column::ColumnBlock {
         column::ColumnBlock::new().children(children)
     }
 
     // DividerBlock
 
-    pub fn build_divider() -> BlockType {
-        BlockType::Divider {
+    pub fn build_divider() -> Block {
+        Block::Divider {
             divider: std::collections::HashMap::new(),
         }
     }
@@ -369,7 +369,7 @@ impl BlockType {
     }
 
     pub fn new_numbered_list_item_with_children(
-        children: Vec<BlockType>,
+        children: Vec<Block>,
     ) -> numbered_list_item::NumberedListItemBlock {
         numbered_list_item::NumberedListItemBlock::new().children(children)
     }
@@ -427,7 +427,7 @@ impl BlockType {
         quote::QuoteBlock::new()
     }
 
-    pub fn new_quote_with_children(children: Vec<BlockType>) -> quote::QuoteBlock {
+    pub fn new_quote_with_children(children: Vec<Block>) -> quote::QuoteBlock {
         quote::QuoteBlock::new().children(children)
     }
 
@@ -584,7 +584,7 @@ mod unit_tests {
         }
         "#;
 
-        let block = serde_json::from_str::<Block>(json_data).unwrap();
+        let block = serde_json::from_str::<BlockResponse>(json_data).unwrap();
 
         assert_eq!(block.object, "block");
         assert_eq!(block.id, "b943dc57-3260-4486-a1c8-f83cf8c12fc3");
@@ -616,7 +616,7 @@ mod unit_tests {
         assert!(!block.in_trash);
 
         match block.details {
-            BlockType::Bookmark { bookmark } => {
+            Block::Bookmark { bookmark } => {
                 assert_eq!(bookmark.url, "https://example.com");
 
                 let rich_text = bookmark.caption.first().unwrap();
@@ -664,10 +664,10 @@ mod unit_tests {
         }
         "#;
 
-        let block = serde_json::from_str::<Block>(json_data).unwrap();
+        let block = serde_json::from_str::<BlockResponse>(json_data).unwrap();
 
         match block.details {
-            BlockType::File(file) => match file.file {
+            Block::File(file) => match file.file {
                 crate::others::file::File::Uploaded(uploaded_file) => {
                     assert_eq!(
                         uploaded_file.name,
@@ -715,12 +715,12 @@ mod unit_tests {
         }
         "#;
 
-        let block = serde_json::from_str::<Block>(json_data).unwrap();
+        let block = serde_json::from_str::<BlockResponse>(json_data).unwrap();
 
         println!("{:?}", block);
 
         match block.details {
-            BlockType::Image(image) => match image.image {
+            Block::Image(image) => match image.image {
                 crate::others::file::File::Uploaded(uploaded_file) => {
                     assert_eq!(
                         uploaded_file.file.url,

--- a/src/block/numbered_list_item.rs
+++ b/src/block/numbered_list_item.rs
@@ -17,12 +17,12 @@ pub struct NumberedListItemBlock {
     /// It can only be specified when making a block creation request.
     /// If you need to retrieve the child blocks, you will have to send a request to this block again.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<super::BlockType>>,
+    pub children: Option<Vec<super::Block>>,
 }
 
 impl NumberedListItemBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::NumberedListItem {
+    pub fn build(self) -> super::Block {
+        super::Block::NumberedListItem {
             numbered_list_item: self,
         }
     }
@@ -36,7 +36,7 @@ impl NumberedListItemBlock {
         self
     }
 
-    pub fn children(mut self, children: Vec<super::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<super::Block>) -> Self {
         self.children = Some(children);
         self
     }

--- a/src/block/paragraph.rs
+++ b/src/block/paragraph.rs
@@ -14,8 +14,8 @@ pub struct ParagraphBlock {
 }
 
 impl ParagraphBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Paragraph { paragraph: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Paragraph { paragraph: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/pdf.rs
+++ b/src/block/pdf.rs
@@ -9,8 +9,8 @@ pub struct PdfBlock {
 }
 
 impl PdfBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Pdf(self)
+    pub fn build(self) -> super::Block {
+        super::Block::Pdf(self)
     }
 
     pub fn new() -> Self {

--- a/src/block/quote.rs
+++ b/src/block/quote.rs
@@ -15,12 +15,12 @@ pub struct QuoteBlock {
     /// It can only be specified when making a block creation request.
     /// If you need to retrieve the child blocks, you will have to send a request to this block again.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<super::BlockType>>,
+    pub children: Option<Vec<super::Block>>,
 }
 
 impl QuoteBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Quote { quote: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Quote { quote: self }
     }
 
     pub fn new() -> Self {
@@ -32,7 +32,7 @@ impl QuoteBlock {
         self
     }
 
-    pub fn children(mut self, children: Vec<super::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<super::Block>) -> Self {
         self.children = Some(children);
         self
     }

--- a/src/block/synced_block.rs
+++ b/src/block/synced_block.rs
@@ -20,8 +20,8 @@ pub struct SyncedBlockParams {
 }
 
 impl SyncedBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::SyncedBlock { synced_block: self }
+    pub fn build(self) -> super::Block {
+        super::Block::SyncedBlock { synced_block: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/table.rs
+++ b/src/block/table.rs
@@ -22,12 +22,12 @@ pub struct TableBlock {
     /// It can only be specified when making a block creation request.
     /// If you need to retrieve the child blocks, you will have to send a request to this block again.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<super::BlockType>>,
+    pub children: Option<Vec<super::Block>>,
 }
 
 impl TableBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Table { table: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Table { table: self }
     }
 
     pub fn new() -> Self {
@@ -50,7 +50,7 @@ impl TableBlock {
     }
 
     /// Only `table_row` can be specified.
-    pub fn children(mut self, children: Vec<super::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<super::Block>) -> Self {
         if children.len() > u16::MAX as usize {
             panic!("The number of children exceeds the maximum table width.");
         }

--- a/src/block/table_row.rs
+++ b/src/block/table_row.rs
@@ -16,8 +16,8 @@ pub struct TableRowBlock {
 }
 
 impl TableRowBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::TableRow { table_row: self }
+    pub fn build(self) -> super::Block {
+        super::Block::TableRow { table_row: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/template.rs
+++ b/src/block/template.rs
@@ -12,8 +12,8 @@ pub struct TemplateBlock {
 }
 
 impl TemplateBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Template { template: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Template { template: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/to_do.rs
+++ b/src/block/to_do.rs
@@ -16,8 +16,8 @@ pub struct ToDoBlock {
 }
 
 impl ToDoBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::ToDo { to_do: self }
+    pub fn build(self) -> super::Block {
+        super::Block::ToDo { to_do: self }
     }
 
     pub fn new() -> Self {

--- a/src/block/toggle.rs
+++ b/src/block/toggle.rs
@@ -14,12 +14,12 @@ pub struct ToggleBlock {
     /// It can only be specified when making a block creation request.
     /// If you need to retrieve the child blocks, you will have to send a request to this block again.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<super::BlockType>>,
+    pub children: Option<Vec<super::Block>>,
 }
 
 impl ToggleBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Toggle { toggle: self }
+    pub fn build(self) -> super::Block {
+        super::Block::Toggle { toggle: self }
     }
 
     pub fn new() -> Self {
@@ -31,7 +31,7 @@ impl ToggleBlock {
         self
     }
 
-    pub fn children(mut self, children: Vec<super::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<super::Block>) -> Self {
         self.children = Some(children);
         self
     }

--- a/src/block/video.rs
+++ b/src/block/video.rs
@@ -9,8 +9,8 @@ pub struct VideoBlock {
 }
 
 impl VideoBlock {
-    pub fn build(self) -> super::BlockType {
-        super::BlockType::Video(self)
+    pub fn build(self) -> super::Block {
+        super::Block::Video(self)
     }
 
     pub fn new() -> Self {

--- a/src/client/block/append_block_children.rs
+++ b/src/client/block/append_block_children.rs
@@ -13,12 +13,12 @@ pub struct AppendBlockChildrenClient {
     /// The ID of the existing block that the new block should be appended after.
     pub(crate) after: Option<String>,
 
-    pub(crate) children: Vec<crate::block::BlockType>,
+    pub(crate) children: Vec<crate::block::Block>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AppendBlockChildrenRequestBody {
-    pub(crate) children: Vec<crate::block::BlockType>,
+    pub(crate) children: Vec<crate::block::Block>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) after: Option<String>,
@@ -30,7 +30,7 @@ impl AppendBlockChildrenClient {
     // TODO: docs for send
     pub async fn send(
         self,
-    ) -> Result<crate::list_response::ListResponse<crate::block::Block>, NotionError> {
+    ) -> Result<crate::list_response::ListResponse<crate::block::BlockResponse>, NotionError> {
         let block_id = self
             .block_id
             .ok_or(NotionError::NotionRequestParameterError(
@@ -64,8 +64,9 @@ impl AppendBlockChildrenClient {
 
         let body = response.text().await?;
 
-        let block =
-            serde_json::from_str::<crate::list_response::ListResponse<crate::block::Block>>(&body)?;
+        let block = serde_json::from_str::<
+            crate::list_response::ListResponse<crate::block::BlockResponse>,
+        >(&body)?;
 
         Ok(block)
     }
@@ -83,7 +84,7 @@ impl AppendBlockChildrenClient {
     }
 
     /// The ID of the existing block that the new block should be appended after.
-    pub fn children(mut self, children: Vec<crate::block::BlockType>) -> Self {
+    pub fn children(mut self, children: Vec<crate::block::Block>) -> Self {
         self.children = children;
         self
     }

--- a/src/client/block/delete_block.rs
+++ b/src/client/block/delete_block.rs
@@ -10,7 +10,7 @@ pub struct DeleteBlockClient {
 
 impl DeleteBlockClient {
     // TODO: docs for send
-    pub async fn send(self) -> Result<crate::block::Block, NotionError> {
+    pub async fn send(self) -> Result<crate::block::BlockResponse, NotionError> {
         let block_id = self
             .block_id
             .ok_or(NotionError::NotionRequestParameterError(
@@ -33,7 +33,7 @@ impl DeleteBlockClient {
 
         let body = response.text().await?;
 
-        let block = serde_json::from_str::<crate::block::Block>(&body)?;
+        let block = serde_json::from_str::<crate::block::BlockResponse>(&body)?;
 
         Ok(block)
     }

--- a/src/client/block/get_block.rs
+++ b/src/client/block/get_block.rs
@@ -10,7 +10,7 @@ pub struct GetBlockClient {
 
 impl GetBlockClient {
     // TODO: docs for send
-    pub async fn send(self) -> Result<crate::block::Block, NotionError> {
+    pub async fn send(self) -> Result<crate::block::BlockResponse, NotionError> {
         let block_id = self
             .block_id
             .ok_or(NotionError::NotionRequestParameterError(
@@ -33,7 +33,7 @@ impl GetBlockClient {
 
         let body = response.text().await?;
 
-        let block = serde_json::from_str::<crate::block::Block>(&body)?;
+        let block = serde_json::from_str::<crate::block::BlockResponse>(&body)?;
 
         Ok(block)
     }

--- a/src/client/block/get_block_children.rs
+++ b/src/client/block/get_block_children.rs
@@ -16,8 +16,8 @@ impl GetBlockChildrenClient {
     // TODO: docs for send
     pub async fn send(
         self,
-    ) -> Result<crate::list_response::ListResponse<crate::block::Block>, NotionError> {
-        let mut result_blocks: Vec<crate::block::Block> = vec![];
+    ) -> Result<crate::list_response::ListResponse<crate::block::BlockResponse>, NotionError> {
+        let mut result_blocks: Vec<crate::block::BlockResponse> = vec![];
 
         let mut page_size_remain = self.page_size;
 
@@ -62,7 +62,7 @@ impl GetBlockChildrenClient {
             let body = response.text().await?;
 
             let block_list_response = serde_json::from_str::<
-                crate::list_response::ListResponse<crate::block::Block>,
+                crate::list_response::ListResponse<crate::block::BlockResponse>,
             >(&body)?;
 
             result_blocks.extend(block_list_response.results);

--- a/src/client/block/update_block.rs
+++ b/src/client/block/update_block.rs
@@ -13,13 +13,13 @@ pub struct UpdateBlockClient {
     /// The ID of the existing block that the new block should be appended after.
     pub(crate) archived: Option<bool>,
 
-    pub(crate) block: Option<crate::block::BlockType>,
+    pub(crate) block: Option<crate::block::Block>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateBlockRequestBody {
     #[serde(flatten)]
-    pub(crate) block: crate::block::BlockType,
+    pub(crate) block: crate::block::Block,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) archived: Option<bool>,
@@ -27,7 +27,7 @@ pub struct UpdateBlockRequestBody {
 
 impl UpdateBlockClient {
     // TODO: docs for send
-    pub async fn send(self) -> Result<crate::block::Block, NotionError> {
+    pub async fn send(self) -> Result<crate::block::BlockResponse, NotionError> {
         let block_id = self
             .block_id
             .ok_or(NotionError::NotionRequestParameterError(
@@ -65,7 +65,7 @@ impl UpdateBlockClient {
 
         let body = response.text().await?;
 
-        let block = serde_json::from_str::<crate::block::Block>(&body)?;
+        let block = serde_json::from_str::<crate::block::BlockResponse>(&body)?;
 
         Ok(block)
     }
@@ -76,7 +76,7 @@ impl UpdateBlockClient {
         self
     }
 
-    pub fn block(mut self, block: crate::block::BlockType) -> Self {
+    pub fn block(mut self, block: crate::block::Block) -> Self {
         self.block = Some(block);
         self
     }

--- a/tests/block/crud_audio_block.rs
+++ b/tests/block/crud_audio_block.rs
@@ -17,7 +17,7 @@ mod integration_tests {
         let request = client
             .append_block_children()
             .block_id(block_id.clone())
-            .children(vec![notionrs::block::BlockType::new_audio()
+            .children(vec![notionrs::block::Block::new_audio()
                 .url("https://example.com/sample.wav")
                 .build()]);
 
@@ -54,7 +54,7 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let audio_block = match response.details {
-            notionrs::block::BlockType::Audio(audio) => audio,
+            notionrs::block::Block::Audio(audio) => audio,
             e => panic!("{:?}", e),
         };
 

--- a/tests/block/get_block.rs
+++ b/tests/block/get_block.rs
@@ -15,7 +15,7 @@ mod integration_tests {
         let response = request.send().await?;
 
         match response.details {
-            notionrs::block::BlockType::ChildPage { child_page } => {
+            notionrs::block::Block::ChildPage { child_page } => {
                 println!("Title: {}", child_page.title);
             }
             _ => panic!("Unexpected block type!"),


### PR DESCRIPTION
The enum previously named `BlockType` was used to manage block types, and the old `Block` struct represented the common parts returned from the Notion API, with `BlockType` as one of its fields. Since this naming was unclear, the following changes have been made:

- Renamed `struct Block` to `struct BlockResponse`
- Renamed `enum BlockType` to `enum Block`

From now on, the API will use these new names.