### PR TITLE
Fix GitHub Actions to Ignore Rust Tests for Docs-Only Changes and Adjust Docs Build Directory

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        working-directory: docs
+
     strategy:
       matrix:
         node-version:
@@ -28,9 +32,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
-
-      - name: Working Directory
-        run: cd docs
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -14,6 +14,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: docs
+
     strategy:
       matrix:
         node-version:
@@ -43,7 +48,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/.vitepress/dist
+          path: .vitepress/dist
 
   deploy:
     needs: build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,11 @@ name: Unit Test
 
 on:
   push:
+    paths-ignore:
+      - docs
   pull_request:
+    paths-ignore:
+      - docs
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
- Updated the Rust unit tests to skip execution when only changes in the `docs` directory are detected.
- Corrected the base directory for the documentation build.