### PR TITLE
Change created_time and last_edited_time types from string to chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +119,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
 
 [[package]]
 name = "core-foundation"
@@ -389,6 +418,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,12 +565,22 @@ version = "1.0.0-alpha.2"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "chrono",
  "dotenvy",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1269,6 +1331,15 @@ checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 [dependencies]
 async-recursion = "~1.1.0"
 async-trait = "0.1.83"
-chrono = "0.4.38"
+chrono = { version = "0.4.38", features = ["serde"] }
 dotenvy = "0.15.0"
 reqwest = "0.12.8"
 serde = { version = "1.0.213", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 [dependencies]
 async-recursion = "~1.1.0"
 async-trait = "0.1.83"
+chrono = "0.4.38"
 dotenvy = "0.15.0"
 reqwest = "0.12.8"
 serde = { version = "1.0.213", features = ["derive"] }

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -81,9 +81,15 @@ pub struct BlockResponse {
 
     pub parent: crate::others::parent::Parent,
 
-    pub created_time: String,
+    /// This value is provided in ISO 8601 format.
+    /// To convert it back to the original string,
+    /// use the `.to_rfc3339()` method from `chrono`.
+    pub created_time: chrono::DateTime<chrono::Utc>,
 
-    pub last_edited_time: String,
+    /// This value is provided in ISO 8601 format.
+    /// To convert it back to the original string,
+    /// use the `.to_rfc3339()` method from `chrono`.
+    pub last_edited_time: chrono::DateTime<chrono::Utc>,
 
     pub created_by: crate::user::User,
 
@@ -207,6 +213,8 @@ pub enum Block {
 
 #[cfg(test)]
 mod unit_tests {
+    use chrono::TimeZone;
+
     use super::*;
 
     #[test]
@@ -271,8 +279,12 @@ mod unit_tests {
             _ => panic!(),
         }
 
-        assert_eq!(block.created_time, "2024-08-17T02:50:00.000Z");
-        assert_eq!(block.last_edited_time, "2024-08-17T02:50:00.000Z");
+        let expected_created_time = chrono::Utc.with_ymd_and_hms(2024, 8, 17, 2, 50, 0).unwrap();
+        assert_eq!(block.created_time, expected_created_time);
+
+        let expected_last_edited_time =
+            chrono::Utc.with_ymd_and_hms(2024, 8, 17, 2, 50, 0).unwrap();
+        assert_eq!(block.last_edited_time, expected_last_edited_time);
 
         match block.created_by {
             crate::user::User::Bot(bot) => {


### PR DESCRIPTION
The types of created_time and last_edited_time in Block have been changed from strings to chrono types.

Additionally, the corresponding unit tests, integration tests, and documentation have been updated.
