### PR TITLE
Fix documentation build artifact path

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: .vitepress/dist
+          path: docs/.vitepress/dist
 
   deploy:
     needs: build


### PR DESCRIPTION
This update corrects the path used for storing build artifacts in the documentation process. The previous path was incorrect, leading to issues during the build. With this fix, the documentation build should now store artifacts in the proper location.