### PR TITLE
Update VitePress Root Path and Trigger Documentation Build on Main Branch Push

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -2,6 +2,8 @@ name: Build and Deploy Documentation
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   workflow_dispatch:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
   title: "NotionRs",
   description:
     "🦀 Community-driven Notion API client for Rust , offering complete deserialization support and providing a secure way to access properties! 🔒",
+  base: "notionrs",
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
 


### PR DESCRIPTION
## Changes
- **ci**: Configure the CI to trigger a documentation build when changes are pushed to the main branch.
- **chore(vitepress)**: Modify the root path for the documentation in the VitePress configuration.

This PR updates the CI pipeline to automatically build documentation on every push to the main branch, and adjusts the root path of the documentation in VitePress for better organization or structure.