### PR TITLE
Fix Notation for Documentation Root Path

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,7 +5,7 @@ export default defineConfig({
   title: "NotionRs",
   description:
     "🦀 Community-driven Notion API client for Rust , offering complete deserialization support and providing a secure way to access properties! 🔒",
-  base: "notionrs",
+  base: "/notionrs/",
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
 


### PR DESCRIPTION
The base path needed to be enclosed with `/`, so this has been corrected. For more details, please refer to [Setting a Public Base Path](https://vitepress.dev/guide/deploy#setting-a-public-base-path).