### PR TITLE
Move `tokio` and `dotenvy` to Development Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ readme = "README.md"
 async-recursion = "~1.1.0"
 async-trait = "0.1.83"
 chrono = { version = "0.4.38", features = ["serde"] }
-dotenvy = "0.15.0"
 reqwest = "0.12.8"
 serde = { version = "1.0.213", features = ["derive"] }
 serde_json = "1.0.132"
 thiserror = "1.0.65"
+
+[dev-dependencies]
 tokio = { version = "1.41.0", features = ["full"] }
+dotenvy = "0.15.0"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,8 +15,6 @@ impl Client {
     pub fn new() -> Self {
         let mut headers = reqwest::header::HeaderMap::new();
 
-        dotenvy::dotenv().ok();
-
         let secret = env::var("NOTION_TOKEN").unwrap_or_else(|_| String::new());
 
         headers.insert(


### PR DESCRIPTION
- Removed `tokio` to give crate users the flexibility to choose their own async runtime, as no specific `tokio`-exclusive features are being used.
- `dotenvy` is now used only in tests to prevent accidental loading of `.env` files during normal usage.
