### PR TITLE
docs(cargo): update GitHub link from VitePress to NotionRs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -46,7 +46,7 @@ export default defineConfig({
     ],
 
     socialLinks: [
-      { icon: "github", link: "https://github.com/vuejs/vitepress" },
+      { icon: "github", link: "https://github.com/46ki75/notionrs" },
     ],
   },
 });


### PR DESCRIPTION
This PR updates the GitHub link in the VitePress documentation from the previous URL to the official repository for notionrs. The change ensures that users are directed to the correct source for the project.