### PR TITLE
Support for Notion Page Operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 edition = "2021"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This project is currently under active development and is not yet ready for production use. Features and API stability may change without notice. Contributions and feedback are welcome!
 
 - [♻ Release Notes](https://github.com/46ki75/notionrs/releases)
-- [💡 User Guide | Documentation](https://github.com/46ki75/notionrs/releases) (Under Construction)
+- [💡 User Guide | Documentation](https://46ki75.github.io/notionrs/) (Under Construction)
 - [🛠️ API Reference (docs.rs)](https://docs.rs/notionrs/latest/notionrs/)
 
 ## Features currently released

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -84,12 +84,12 @@ pub struct BlockResponse {
     /// This value is provided in ISO 8601 format.
     /// To convert it back to the original string,
     /// use the `.to_rfc3339()` method from `chrono`.
-    pub created_time: chrono::DateTime<chrono::Utc>,
+    pub created_time: chrono::DateTime<chrono::FixedOffset>,
 
     /// This value is provided in ISO 8601 format.
     /// To convert it back to the original string,
     /// use the `.to_rfc3339()` method from `chrono`.
-    pub last_edited_time: chrono::DateTime<chrono::Utc>,
+    pub last_edited_time: chrono::DateTime<chrono::FixedOffset>,
 
     pub created_by: crate::user::User,
 

--- a/src/client/page/get_page.rs
+++ b/src/client/page/get_page.rs
@@ -12,12 +12,6 @@ pub struct GetPageClient {
 }
 
 impl GetPageClient {
-    /// Send a request specifying generics.
-    ///
-    /// Create a struct with generics like `send::<MyResponse>()`.
-    /// When the response type is not specific,
-    /// use `send::<HashMap<String, PageProperty>>()`.
-    /// (Type inference for the property field cannot be used.)
     pub async fn send(self) -> Result<PageResponse, Error> {
         match self.page_id {
             Some(id) => {

--- a/src/client/page/mod.rs
+++ b/src/client/page/mod.rs
@@ -1,3 +1,4 @@
 pub mod create_page;
 pub mod get_page;
 pub mod get_page_property_item;
+pub mod update_page;

--- a/src/client/page/update_page.rs
+++ b/src/client/page/update_page.rs
@@ -1,0 +1,96 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{api_error::ApiError, Error},
+    page::page_response::PageResponse,
+};
+
+#[derive(Debug, Default)]
+pub struct UpdatePageClient {
+    /// The reqwest http client
+    pub(crate) reqwest_client: reqwest::Client,
+
+    pub(crate) page_id: Option<String>,
+
+    pub(crate) properties: std::collections::HashMap<String, crate::page::properties::PageProperty>,
+
+    pub(crate) icon: Option<crate::others::icon::Icon>,
+
+    pub(crate) cover: Option<crate::File>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdatePageRequestBody {
+    pub(crate) properties: std::collections::HashMap<String, crate::page::properties::PageProperty>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) icon: Option<crate::others::icon::Icon>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cover: Option<crate::File>,
+}
+
+impl UpdatePageClient {
+    pub async fn send(self) -> Result<PageResponse, Error> {
+        let page_id = self.page_id.ok_or(crate::error::Error::RequestParameter(
+            "You need to specify either the page_id.".to_string(),
+        ))?;
+
+        let request_body_struct = UpdatePageRequestBody {
+            properties: self.properties,
+            icon: self.icon,
+            cover: self.cover,
+        };
+
+        let request_body = serde_json::to_string(&request_body_struct)?;
+
+        let url = format!("https://api.notion.com/v1/pages/{}", page_id);
+
+        println!("{}", request_body);
+
+        let request = self
+            .reqwest_client
+            .patch(url)
+            .header("Content-Type", "application/json")
+            .body(request_body);
+
+        let response = request.send().await?;
+
+        if !response.status().is_success() {
+            let error_body = response.text().await?;
+
+            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+
+            return Err(Error::Api(Box::new(error_json)));
+        }
+
+        let body = response.text().await?;
+
+        let page: PageResponse = serde_json::from_str::<PageResponse>(&body)?;
+
+        Ok(page)
+    }
+
+    pub fn page_id<T: AsRef<str>>(mut self, page_id: T) -> Self {
+        self.page_id = Some(page_id.as_ref().to_string());
+        self
+    }
+
+    pub fn properties(
+        mut self,
+        properties: std::collections::HashMap<String, crate::page::properties::PageProperty>,
+    ) -> Self {
+        self.properties = properties;
+        self
+    }
+
+    pub fn icon(mut self, icon: crate::others::icon::Icon) -> Self {
+        self.icon = Some(icon);
+        self
+    }
+
+    pub fn cover(mut self, cover: crate::File) -> Self {
+        self.cover = Some(cover);
+        self
+    }
+}

--- a/src/database/properties/multi_select.rs
+++ b/src/database/properties/multi_select.rs
@@ -105,30 +105,42 @@ mod unit_tests {
 
         assert_eq!(
             options[0].id,
-            ("5de29601-9c24-4b04-8629-0bca891c5120".to_string())
+            Some("5de29601-9c24-4b04-8629-0bca891c5120".to_string())
         );
         assert_eq!(options[0].name, "Duc Loi Market");
-        assert_eq!(options[0].color, crate::others::select::SelectColor::Blue);
+        assert_eq!(
+            options[0].color,
+            Some(crate::others::select::SelectColor::Blue)
+        );
 
         assert_eq!(
             options[1].id,
-            ("385890b8-fe15-421b-b214-b02959b0f8d9".to_string())
+            Some("385890b8-fe15-421b-b214-b02959b0f8d9".to_string())
         );
         assert_eq!(options[1].name, "Rainbow Grocery");
-        assert_eq!(options[1].color, crate::others::select::SelectColor::Gray);
+        assert_eq!(
+            options[1].color,
+            Some(crate::others::select::SelectColor::Gray)
+        );
 
         assert_eq!(
             options[2].id,
-            ("72ac0a6c-9e00-4e8c-80c5-720e4373e0b9".to_string())
+            Some("72ac0a6c-9e00-4e8c-80c5-720e4373e0b9".to_string())
         );
         assert_eq!(options[2].name, "Nijiya Market");
-        assert_eq!(options[2].color, crate::others::select::SelectColor::Purple);
+        assert_eq!(
+            options[2].color,
+            Some(crate::others::select::SelectColor::Purple)
+        );
 
         assert_eq!(
             options[3].id,
-            ("9556a8f7-f4b0-4e11-b277-f0af1f8c9490".to_string())
+            Some("9556a8f7-f4b0-4e11-b277-f0af1f8c9490".to_string())
         );
         assert_eq!(options[3].name, "Gus's Community Market");
-        assert_eq!(options[3].color, crate::others::select::SelectColor::Yellow);
+        assert_eq!(
+            options[3].color,
+            Some(crate::others::select::SelectColor::Yellow)
+        );
     }
 }

--- a/src/database/properties/select.rs
+++ b/src/database/properties/select.rs
@@ -100,23 +100,32 @@ mod unit_tests {
 
         assert_eq!(
             options[0].id,
-            ("e28f74fc-83a7-4469-8435-27eb18f9f9de".to_string())
+            Some("e28f74fc-83a7-4469-8435-27eb18f9f9de".to_string())
         );
         assert_eq!(options[0].name, "🥦Vegetable");
-        assert_eq!(options[0].color, crate::others::select::SelectColor::Purple);
+        assert_eq!(
+            options[0].color,
+            Some(crate::others::select::SelectColor::Purple)
+        );
 
         assert_eq!(
             options[1].id,
-            ("6132d771-b283-4cd9-ba44-b1ed30477c7f".to_string())
+            Some("6132d771-b283-4cd9-ba44-b1ed30477c7f".to_string())
         );
         assert_eq!(options[1].name, "🍎Fruit");
-        assert_eq!(options[1].color, crate::others::select::SelectColor::Red);
+        assert_eq!(
+            options[1].color,
+            Some(crate::others::select::SelectColor::Red)
+        );
 
         assert_eq!(
             options[2].id,
-            ("fc9ea861-820b-4f2b-bc32-44ed9eca873c".to_string())
+            Some("fc9ea861-820b-4f2b-bc32-44ed9eca873c".to_string())
         );
         assert_eq!(options[2].name, "💪Protein");
-        assert_eq!(options[2].color, crate::others::select::SelectColor::Yellow);
+        assert_eq!(
+            options[2].color,
+            Some(crate::others::select::SelectColor::Yellow)
+        );
     }
 }

--- a/src/database/properties/status.rs
+++ b/src/database/properties/status.rs
@@ -130,27 +130,33 @@ mod unit_tests {
 
         assert_eq!(
             options[0].id,
-            ("034ece9a-384d-4d1f-97f7-7f685b29ae9b".to_string())
+            Some("034ece9a-384d-4d1f-97f7-7f685b29ae9b".to_string())
         );
         assert_eq!(options[0].name, "Not started");
         assert_eq!(
             options[0].color,
-            crate::others::select::SelectColor::Default
+            Some(crate::others::select::SelectColor::Default)
         );
 
         assert_eq!(
             options[1].id,
-            ("330aeafb-598c-4e1c-bc13-1148aa5963d3".to_string())
+            Some("330aeafb-598c-4e1c-bc13-1148aa5963d3".to_string())
         );
         assert_eq!(options[1].name, "In progress");
-        assert_eq!(options[1].color, crate::others::select::SelectColor::Blue);
+        assert_eq!(
+            options[1].color,
+            Some(crate::others::select::SelectColor::Blue)
+        );
 
         assert_eq!(
             options[2].id,
-            ("497e64fb-01e2-41ef-ae2d-8a87a3bb51da".to_string())
+            Some("497e64fb-01e2-41ef-ae2d-8a87a3bb51da".to_string())
         );
         assert_eq!(options[2].name, "Done");
-        assert_eq!(options[2].color, crate::others::select::SelectColor::Green);
+        assert_eq!(
+            options[2].color,
+            Some(crate::others::select::SelectColor::Green)
+        );
 
         let groups = &status.status.groups;
         assert_eq!(groups.len(), 3);

--- a/src/others/select.rs
+++ b/src/others/select.rs
@@ -2,9 +2,13 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct Select {
-    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
     pub name: String,
-    pub color: SelectColor,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<SelectColor>,
 }
 
 impl Select {
@@ -12,7 +16,7 @@ impl Select {
     where
         T: AsRef<str>,
     {
-        self.id = id.as_ref().to_string();
+        self.id = Some(id.as_ref().to_string());
         self
     }
 
@@ -25,8 +29,17 @@ impl Select {
     }
 
     pub fn color(mut self, color: SelectColor) -> Self {
-        self.color = color;
+        self.color = Some(color);
         self
+    }
+}
+
+impl<T> From<T> for Select
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        Self::default().name(value)
     }
 }
 

--- a/src/page/page_response.rs
+++ b/src/page/page_response.rs
@@ -9,8 +9,8 @@ use crate::{
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PageResponse {
     pub id: String,
-    pub created_time: chrono::DateTime<chrono::Utc>,
-    pub last_edited_time: chrono::DateTime<chrono::Utc>,
+    pub created_time: chrono::DateTime<chrono::FixedOffset>,
+    pub last_edited_time: chrono::DateTime<chrono::FixedOffset>,
     pub created_by: User,
     pub last_edited_by: User,
     pub cover: Option<File>,

--- a/src/page/properties/button.rs
+++ b/src/page/properties/button.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 pub struct PageButtonProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// Always `"button"`

--- a/src/page/properties/checkbox.rs
+++ b/src/page/properties/checkbox.rs
@@ -24,10 +24,20 @@ use serde::{Deserialize, Serialize};
 pub struct PageCheckboxProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// Whether the checkbox is checked (`true`) or unchecked (`false`).
     pub checkbox: bool,
+}
+
+impl From<bool> for PageCheckboxProperty {
+    fn from(value: bool) -> Self {
+        Self {
+            id: None,
+            checkbox: value,
+        }
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/created_by.rs
+++ b/src/page/properties/created_by.rs
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 pub struct PageCreatedByProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// A [user object](https://developers.notion.com/reference/user)

--- a/src/page/properties/created_time.rs
+++ b/src/page/properties/created_time.rs
@@ -25,11 +25,12 @@ use serde::{Deserialize, Serialize};
 pub struct PageCreatedTimeProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// The date and time that the page was created.
     ///The created_time value can’t be updated.
-    pub created_time: chrono::DateTime<chrono::Utc>,
+    pub created_time: chrono::DateTime<chrono::FixedOffset>,
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/email.rs
+++ b/src/page/properties/email.rs
@@ -32,14 +32,34 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PageEmailProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// A string describing an email address.
     pub email: Option<String>,
+}
+
+impl PageEmailProperty {
+    pub fn email<T>(mut self, email: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        self.email = Some(email.as_ref().to_string());
+        self
+    }
+}
+
+impl<T> From<T> for PageEmailProperty
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        Self::default().email(value)
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/files.rs
+++ b/src/page/properties/files.rs
@@ -31,15 +31,41 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PageFilesProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// An array of objects containing information
     /// about the [files](https://developers.notion.com/reference/file-object).
+    ///
+    /// When creating, both the external path of the file and `name` are required.
     pub files: Vec<crate::others::file::File>,
+}
+
+impl PageFilesProperty {
+    pub fn files(mut self, files: Vec<crate::others::file::File>) -> Self {
+        self.files = files;
+        self
+    }
+}
+
+impl<T> From<T> for PageFilesProperty
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        let file = crate::File::new().url(value.as_ref()).name(value.as_ref());
+        Self::default().files(vec![file])
+    }
+}
+
+impl From<crate::File> for PageFilesProperty {
+    fn from(value: crate::File) -> Self {
+        Self::default().files(vec![value])
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/formula.rs
+++ b/src/page/properties/formula.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 pub struct PageFormulaProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// Formula property value objects represent the result of evaluating
@@ -69,7 +70,7 @@ pub struct FormulaBoolean {
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 pub struct FormulaDate {
     /// Calculated value of the database property
-    pub date: Option<chrono::DateTime<chrono::Utc>>,
+    pub date: Option<chrono::DateTime<chrono::FixedOffset>>,
 }
 
 /// ```json

--- a/src/page/properties/last_edited_by.rs
+++ b/src/page/properties/last_edited_by.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 pub struct PageLastEditedByProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// A [user object](https://developers.notion.com/reference/user)

--- a/src/page/properties/last_edited_time.rs
+++ b/src/page/properties/last_edited_time.rs
@@ -24,10 +24,11 @@ use serde::{Deserialize, Serialize};
 pub struct PageLastEditedTimeProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// The date and time that the page was last edited.
-    pub last_edited_time: chrono::DateTime<chrono::Utc>,
+    pub last_edited_time: chrono::DateTime<chrono::FixedOffset>,
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/multi_select.rs
+++ b/src/page/properties/multi_select.rs
@@ -31,14 +31,22 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PageMultiSelectProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// Array of Select object
     pub multi_select: Vec<crate::others::select::Select>,
+}
+
+impl PageMultiSelectProperty {
+    pub fn multi_select(mut self, multi_select: Vec<crate::others::select::Select>) -> Self {
+        self.multi_select = multi_select;
+        self
+    }
 }
 
 // # --------------------------------------------------------------------------------
@@ -85,22 +93,22 @@ mod unit_tests {
 
         assert_eq!(
             multi_select.multi_select.first().unwrap().id,
-            ("959ba3e3-5a64-4ee6-864b-9e94ddc024d5".to_string())
+            Some("959ba3e3-5a64-4ee6-864b-9e94ddc024d5".to_string())
         );
         assert_eq!(multi_select.multi_select.first().unwrap().name, "HTML");
         assert_eq!(
             multi_select.multi_select.first().unwrap().color,
-            crate::others::select::SelectColor::Orange
+            Some(crate::others::select::SelectColor::Orange)
         );
 
         assert_eq!(
             multi_select.multi_select.get(1).unwrap().id,
-            ("f22b05c9-0225-4dee-b25b-db7e63a47e0b".to_string())
+            Some("f22b05c9-0225-4dee-b25b-db7e63a47e0b".to_string())
         );
         assert_eq!(multi_select.multi_select.get(1).unwrap().name, "CSS");
         assert_eq!(
             multi_select.multi_select.get(1).unwrap().color,
-            crate::others::select::SelectColor::Blue
+            Some(crate::others::select::SelectColor::Blue)
         );
     }
 }

--- a/src/page/properties/number.rs
+++ b/src/page/properties/number.rs
@@ -20,14 +20,31 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PageNumberProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// A number representing some value.
     pub number: Option<f64>,
+}
+
+impl PageNumberProperty {
+    pub fn number(mut self, number: f64) -> Self {
+        self.number = Some(number);
+        self
+    }
+}
+
+impl<T> From<T> for PageNumberProperty
+where
+    T: Into<f64>,
+{
+    fn from(value: T) -> Self {
+        Self::default().number(value.into())
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/people.rs
+++ b/src/page/properties/people.rs
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 pub struct PagePeopleProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// An array of user objects.

--- a/src/page/properties/phone_number.rs
+++ b/src/page/properties/phone_number.rs
@@ -20,14 +20,34 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PagePhoneNumberProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// A string representing a phone number. No phone number format is enforced.
     pub phone_number: Option<String>,
+}
+
+impl PagePhoneNumberProperty {
+    pub fn phone_number<T>(mut self, phone_number: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        self.phone_number = Some(phone_number.as_ref().to_string());
+        self
+    }
+}
+
+impl<T> From<T> for PagePhoneNumberProperty
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        Self::default().phone_number(value)
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/relation.rs
+++ b/src/page/properties/relation.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize};
 pub struct PageRelationProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// An array of related page references.

--- a/src/page/properties/rich_text.rs
+++ b/src/page/properties/rich_text.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::ToPlainText;
+
 /// <https://developers.notion.com/reference/page-property-values#rich-text>
 ///
 /// - `$.['*'].id`: An underlying identifier for the property.
@@ -42,10 +44,39 @@ use serde::{Deserialize, Serialize};
 pub struct PageRichTextProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// An array of [rich text objects](https://developers.notion.com/reference/rich-text)
     pub rich_text: Vec<crate::others::rich_text::RichText>,
+}
+
+impl<T> From<T> for PageRichTextProperty
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        Self {
+            id: None,
+            rich_text: vec![crate::RichText::from(value)],
+        }
+    }
+}
+
+impl From<crate::RichText> for PageRichTextProperty {
+    fn from(rich_text: crate::RichText) -> Self {
+        Self {
+            id: None,
+            rich_text: vec![rich_text],
+        }
+    }
+}
+
+impl std::fmt::Display for PageRichTextProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let plain_text = self.rich_text.to_plain_text();
+        write!(f, "{}", plain_text)
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/rollup.rs
+++ b/src/page/properties/rollup.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct PageRollupProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 }
 

--- a/src/page/properties/select.rs
+++ b/src/page/properties/select.rs
@@ -24,14 +24,32 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PageSelectProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// Select object (optional)
     pub select: Option<crate::others::select::Select>,
+}
+
+impl PageSelectProperty {
+    pub fn select(mut self, select: crate::others::select::Select) -> Self {
+        self.select = Some(select);
+        self
+    }
+}
+
+impl<T> From<T> for PageSelectProperty
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        let select = crate::others::select::Select::from(value);
+        Self::default().select(select)
+    }
 }
 
 // # --------------------------------------------------------------------------------
@@ -71,12 +89,12 @@ mod unit_tests {
         assert_eq!(select.id, Some("chOy".to_string()));
         assert_eq!(
             select.select.as_ref().unwrap().id,
-            ("eede87ce-52db-4b16-9931-2bc40687d697".to_string())
+            Some("eede87ce-52db-4b16-9931-2bc40687d697".to_string())
         );
         assert_eq!(select.select.as_ref().unwrap().name, "TODO");
         assert_eq!(
             select.select.as_ref().unwrap().color,
-            crate::others::select::SelectColor::Default
+            Some(crate::others::select::SelectColor::Default)
         );
     }
 }

--- a/src/page/properties/status.rs
+++ b/src/page/properties/status.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 pub struct PageStatusProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// Select object
@@ -71,12 +72,12 @@ mod unit_tests {
         assert_eq!(status.id, Some("xx%7Cd".to_string()));
         assert_eq!(
             status.status.id,
-            ("4a1accbf-6716-4cf2-9034-5877581fc5f6".to_string())
+            Some("4a1accbf-6716-4cf2-9034-5877581fc5f6".to_string())
         );
         assert_eq!(status.status.name, "Not started");
         assert_eq!(
             status.status.color,
-            crate::others::select::SelectColor::Default
+            Some(crate::others::select::SelectColor::Default)
         );
     }
 }

--- a/src/page/properties/unique_id.rs
+++ b/src/page/properties/unique_id.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 pub struct PageUniqueIdProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing)]
     pub id: Option<String>,
 
     /// A unique ID assigned through auto increment

--- a/src/page/properties/url.rs
+++ b/src/page/properties/url.rs
@@ -20,14 +20,34 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PageUrlProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
+    #[serde(skip_serializing)]
     pub id: Option<String>,
 
     /// A string that describes a web address.
     pub url: Option<String>,
+}
+
+impl PageUrlProperty {
+    pub fn url<T>(mut self, url: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        self.url = Some(url.as_ref().to_string());
+        self
+    }
+}
+
+impl<T> From<T> for PageUrlProperty
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        Self::default().url(value)
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/tests/page/crud_page.rs
+++ b/tests/page/crud_page.rs
@@ -25,7 +25,36 @@ mod integration_tests {
             )),
         );
 
-        let request = client.create_page().properties(properties).page_id(page_id);
+        let request = client
+            .create_page()
+            .properties(properties)
+            .page_id(page_id)
+            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from('🚧')))
+            .cover(notionrs::File::External(notionrs::ExternalFile::from(
+                "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
+            )));
+
+        let response = request.send().await?;
+
+        // # --------------------------------------------------------------------------------
+        //
+        // update_page
+        //
+        // # --------------------------------------------------------------------------------
+
+        let mut properties = std::collections::HashMap::new();
+
+        properties.insert(
+            "title".to_string(),
+            notionrs::page::PageProperty::Title(notionrs::page::PageTitleProperty::from(
+                "My Page Title (Changed)",
+            )),
+        );
+
+        let request = client
+            .create_page()
+            .properties(properties)
+            .page_id(response.id);
 
         let response = request.send().await?;
 

--- a/tests/page/crud_page_with_database.rs
+++ b/tests/page/crud_page_with_database.rs
@@ -1,0 +1,233 @@
+mod integration_tests {
+
+    #[tokio::test]
+    async fn crud_page_with_database() -> Result<(), notionrs::error::Error> {
+        dotenvy::dotenv().ok();
+
+        let page_id = std::env::var("NOTION_PAGE_ID").unwrap_or_else(|_| String::new());
+
+        let client = notionrs::client::Client::new();
+
+        let mut properties = std::collections::HashMap::new();
+
+        properties.insert(
+            "Title".to_string(),
+            notionrs::database::DatabaseProperty::Title(
+                notionrs::database::DatabaseTitleProperty::default(),
+            ),
+        );
+
+        properties.insert(
+            "My Checkbox".to_string(),
+            notionrs::database::DatabaseProperty::Checkbox(
+                notionrs::database::DatabaseCheckboxProperty::default(),
+            ),
+        );
+
+        properties.insert(
+            "Date".to_string(),
+            notionrs::database::DatabaseProperty::Date(
+                notionrs::database::DatabaseDateProperty::default(),
+            ),
+        );
+
+        properties.insert(
+            "email".to_string(),
+            notionrs::database::DatabaseProperty::Email(
+                notionrs::database::DatabaseEmailProperty::default(),
+            ),
+        );
+
+        properties.insert(
+            "Files & Media".to_string(),
+            notionrs::database::DatabaseProperty::Files(
+                notionrs::database::DatabaseFilesProperty::default(),
+            ),
+        );
+
+        let options = vec![
+            notionrs::Select::default()
+                .color(notionrs::SelectColor::Blue)
+                .name("IT")
+                .id("id"),
+            notionrs::Select::default()
+                .color(notionrs::SelectColor::Red)
+                .name("SoC")
+                .id("id"),
+            notionrs::Select::default()
+                .color(notionrs::SelectColor::Green)
+                .name("SoC")
+                .id("id"),
+        ];
+
+        properties.insert(
+            "Tags".to_string(),
+            notionrs::database::DatabaseProperty::MultiSelect(
+                notionrs::database::DatabaseMultiSelectProperty::default().options(options.clone()),
+            ),
+        );
+
+        properties.insert(
+            "Number".to_string(),
+            notionrs::database::DatabaseProperty::Number(
+                notionrs::database::DatabaseNumberProperty::default(),
+            ),
+        );
+
+        properties.insert(
+            "People".to_string(),
+            notionrs::database::DatabaseProperty::People(
+                notionrs::database::DatabasePeopleProperty::default(),
+            ),
+        );
+
+        properties.insert(
+            "Phone".to_string(),
+            notionrs::database::DatabaseProperty::PhoneNumber(
+                notionrs::database::DatabasePhoneNumberProperty::default(),
+            ),
+        );
+
+        properties.insert(
+            "Rich Text".to_string(),
+            notionrs::database::DatabaseProperty::RichText(
+                notionrs::database::DatabaseRichTextProperty::default(),
+            ),
+        );
+
+        properties.insert(
+            "Select".to_string(),
+            notionrs::database::DatabaseProperty::Select(
+                notionrs::database::DatabaseSelectProperty::default().options(options.clone()),
+            ),
+        );
+
+        properties.insert(
+            "URL".to_string(),
+            notionrs::database::DatabaseProperty::Url(
+                notionrs::database::DatabaseUrlProperty::default(),
+            ),
+        );
+
+        let request = client
+            .create_database()
+            .page_id(page_id)
+            .title(vec![notionrs::RichText::from("Database Title")])
+            .description(vec![notionrs::RichText::from(
+                "Description of the Database",
+            )])
+            .properties(properties)
+            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from('🚧')))
+            .cover(notionrs::File::External(notionrs::ExternalFile::from(
+                "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
+            )));
+
+        let response = request.send().await?;
+
+        // # --------------------------------------------------------------------------------
+        //
+        // create_page
+        //
+        // # --------------------------------------------------------------------------------
+
+        let mut properties = std::collections::HashMap::new();
+
+        properties.insert(
+            "Title".to_string(),
+            notionrs::page::PageProperty::Title(notionrs::page::PageTitleProperty::from(
+                "My Page Title",
+            )),
+        );
+
+        properties.insert(
+            "My Checkbox".to_string(),
+            notionrs::page::PageProperty::Checkbox(notionrs::page::PageCheckboxProperty::from(
+                true,
+            )),
+        );
+
+        properties.insert(
+            "Rich Text".to_string(),
+            notionrs::page::PageProperty::RichText(notionrs::page::PageRichTextProperty::from(
+                "description",
+            )),
+        );
+
+        properties.insert(
+            "Date".to_string(),
+            notionrs::page::PageProperty::Date(notionrs::page::PageDateProperty::from(
+                chrono::DateTime::parse_from_rfc3339("2024-10-26T09:03:00.000Z").unwrap(),
+            )),
+        );
+
+        properties.insert(
+            "email".to_string(),
+            notionrs::page::PageProperty::Email(notionrs::page::PageEmailProperty::from(
+                "info@example.com",
+            )),
+        );
+
+        properties.insert(
+            "Files & Media".to_string(),
+            notionrs::page::PageProperty::Files(notionrs::page::PageFilesProperty::from(
+                "https://example.com/file.txt",
+            )),
+        );
+
+        let option = notionrs::others::select::Select::from("IT");
+
+        properties.insert(
+            "Tags".to_string(),
+            notionrs::page::PageProperty::MultiSelect(
+                notionrs::page::PageMultiSelectProperty::default().multi_select(vec![option]),
+            ),
+        );
+
+        properties.insert(
+            "Number".to_string(),
+            notionrs::page::PageProperty::Number(notionrs::page::PageNumberProperty::from(100000)),
+        );
+
+        properties.insert(
+            "Phone".to_string(),
+            notionrs::page::PageProperty::PhoneNumber(
+                notionrs::page::PagePhoneNumberProperty::from("083-0000-0000"),
+            ),
+        );
+
+        properties.insert(
+            "Select".to_string(),
+            notionrs::page::PageProperty::Select(notionrs::page::PageSelectProperty::from("IT")),
+        );
+
+        properties.insert(
+            "URL".to_string(),
+            notionrs::page::PageProperty::Url(notionrs::page::PageUrlProperty::from("IT")),
+        );
+
+        println!("{}", serde_json::to_string(&properties).unwrap());
+
+        let request = client
+            .create_page()
+            .properties(properties)
+            .database_id(response.id)
+            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from('🚧')))
+            .cover(notionrs::File::External(notionrs::ExternalFile::from(
+                "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
+            )));
+
+        let response = request.send().await?;
+
+        // # --------------------------------------------------------------------------------
+        //
+        // cleanup
+        //
+        // # --------------------------------------------------------------------------------
+
+        let request = client.delete_block().block_id(response.id);
+
+        let _ = request.send().await?;
+
+        Ok(())
+    }
+}

--- a/tests/page/mod.rs
+++ b/tests/page/mod.rs
@@ -1,3 +1,4 @@
 mod crud_page;
+mod crud_page_with_database;
 mod get_page;
 mod get_page_property_item;


### PR DESCRIPTION
This PR adds support for the following Notion API endpoints:

- Create a page
- Retrieve a page property item
- Retrieve a page
- Update page properties
