### PR TITLE
Add Pull Request Templates for Develop and Release Branches

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,22 @@
+## Overview
+
+- Briefly explain the purpose and background of this Pull Request.
+
+## Related Issues
+
+- Link any related issues here (e.g., `#123`). If there are no related issues, write "N/A."
+
+## Changes
+
+- List the main changes made in this PR.
+
+## Checklist
+
+- [ ] The target branch for this PR is either `develop` or `release/*`.
+- [ ] Unit tests have been added.
+- [ ] All unit tests pass.
+- [ ] Documentation has been updated if necessary.
+
+## Additional Notes
+
+- Include any additional information or points of attention for reviewers here.

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,28 @@
+This template is currently intended for use by the repository owner only.
+
+## Release Overview
+
+- Briefly describe the purpose and background of this release.
+
+## Release Details
+
+- List the main changes, new features, and fixes included in this release.
+  - New feature list
+  - Bug fixes
+  - Detailed changes
+
+## Checklist
+
+- [ ] Confirm that the PR target is the `main` branch
+- [ ] Verify that all release contents are included in the `release` branch
+- [ ] Confirm that integration tests have passed
+- [ ] Update documentation if necessary
+- [ ] Update the README if necessary
+- [ ] Update version information (e.g., in `Cargo.toml`)
+- [ ] Confirm that the crate has been published
+- [ ] Confirm that the release tag has been created and pushed
+- [ ] Confirm that release notes have been created
+
+## Additional Notes
+
+- Include any additional information or points of attention post-release.


### PR DESCRIPTION
## Overview

- Created PR templates to help PR authors understand what to include more easily.

## Related Issues

- N/A

## Changes

- `default.md`: Added a PR template for the `develop` and `release/*` branches.
- `release.md`: Added a PR template for PRs from the `release` branch to the `main` branch.

## Checklist

- [x] The target branch for this PR is either `develop` or `release/*`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] Documentation has been updated if necessary.

## Additional Notes

- N/A