### PR TITLE
Replace `ToPlainText` Trait with Standard `Display` Trait

### DIFF
--- a/examples/block_retrieve_a_block.rs
+++ b/examples/block_retrieve_a_block.rs
@@ -1,4 +1,4 @@
-use notionrs::{block::Block, error::Error, Client, ToPlainText};
+use notionrs::{block::Block, error::Error, Client};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -11,7 +11,14 @@ async fn main() -> Result<(), Error> {
     println!("This block's id is {}", response.id);
 
     if let Block::Paragraph { paragraph } = response.block {
-        print!("{}", paragraph.rich_text.to_plain_text());
+        print!(
+            "{}",
+            paragraph
+                .rich_text
+                .iter()
+                .map(|rt| rt.to_string())
+                .collect::<String>()
+        );
         Ok(())
     } else {
         Err(notionrs::error::Error::Custom(

--- a/src/block/bookmark.rs
+++ b/src/block/bookmark.rs
@@ -41,6 +41,12 @@ where
     }
 }
 
+impl std::fmt::Display for BookmarkBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.url)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/bulleted_list_item.rs
+++ b/src/block/bulleted_list_item.rs
@@ -44,6 +44,19 @@ impl From<Vec<crate::others::rich_text::RichText>> for BulletedListItemBlock {
     }
 }
 
+impl std::fmt::Display for BulletedListItemBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| { t.to_string() })
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/callout.rs
+++ b/src/block/callout.rs
@@ -61,6 +61,19 @@ where
     }
 }
 
+impl std::fmt::Display for CalloutBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/child_database.rs
+++ b/src/block/child_database.rs
@@ -12,6 +12,12 @@ pub struct ChildDatabaseBlock {
     pub title: String,
 }
 
+impl std::fmt::Display for ChildDatabaseBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.title)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/child_page.rs
+++ b/src/block/child_page.rs
@@ -12,6 +12,12 @@ pub struct ChildPageBlock {
     pub title: String,
 }
 
+impl std::fmt::Display for ChildPageBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.title)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/code.rs
+++ b/src/block/code.rs
@@ -47,6 +47,19 @@ where
     }
 }
 
+impl std::fmt::Display for CodeBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| { t.to_string() })
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/column.rs
+++ b/src/block/column.rs
@@ -20,3 +20,9 @@ impl ColumnBlock {
         self
     }
 }
+
+impl std::fmt::Display for ColumnBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "")
+    }
+}

--- a/src/block/column_list.rs
+++ b/src/block/column_list.rs
@@ -22,3 +22,9 @@ impl ColumnListBlock {
         self
     }
 }
+
+impl std::fmt::Display for ColumnListBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "")
+    }
+}

--- a/src/block/embed.rs
+++ b/src/block/embed.rs
@@ -33,6 +33,12 @@ where
     }
 }
 
+impl std::fmt::Display for EmbedBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.url)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/equation.rs
+++ b/src/block/equation.rs
@@ -34,6 +34,12 @@ where
     }
 }
 
+impl std::fmt::Display for EquationBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.expression)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/heading.rs
+++ b/src/block/heading.rs
@@ -59,6 +59,19 @@ where
     }
 }
 
+impl std::fmt::Display for HeadingBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| { t.to_string() })
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/link_preview.rs
+++ b/src/block/link_preview.rs
@@ -11,6 +11,12 @@ pub struct LinkPreviewBlock {
     pub url: String,
 }
 
+impl std::fmt::Display for LinkPreviewBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.url)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -205,6 +205,44 @@ pub enum Block {
     Unknown(serde_json::Value),
 }
 
+impl std::fmt::Display for Block {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Block::Audio { audio } => write!(f, "{}", audio),
+            Block::Bookmark { bookmark } => write!(f, "{}", bookmark),
+            Block::Breadcrumb { breadcrumb } => write!(f, "{:?}", breadcrumb),
+            Block::BulletedListItem { bulleted_list_item } => write!(f, "{}", bulleted_list_item),
+            Block::Callout { callout } => write!(f, "{}", callout),
+            Block::ChildDatabase { child_database } => write!(f, "{}", child_database),
+            Block::ChildPage { child_page } => write!(f, "{}", child_page),
+            Block::Code { code } => write!(f, "{}", code),
+            Block::ColumnList { column_list } => write!(f, "{}", column_list),
+            Block::Column { column } => write!(f, "{}", column),
+            Block::Divider { divider } => write!(f, "{:?}", divider),
+            Block::Embed { embed } => write!(f, "{}", embed),
+            Block::Equation { equation } => write!(f, "{}", equation),
+            Block::File { file } => write!(f, "{}", file),
+            Block::Heading1 { heading_1 } => write!(f, "{}", heading_1),
+            Block::Heading2 { heading_2 } => write!(f, "{}", heading_2),
+            Block::Heading3 { heading_3 } => write!(f, "{}", heading_3),
+            Block::Image { image } => write!(f, "{}", image),
+            Block::LinkPreview { link_preview } => write!(f, "{}", link_preview),
+            Block::NumberedListItem { numbered_list_item } => write!(f, "{}", numbered_list_item),
+            Block::Paragraph { paragraph } => write!(f, "{}", paragraph),
+            Block::Pdf { pdf } => write!(f, "{}", pdf),
+            Block::Quote { quote } => write!(f, "{}", quote),
+            Block::SyncedBlock { synced_block } => write!(f, "{}", synced_block),
+            Block::Table { table } => write!(f, "{}", table),
+            Block::TableRow { table_row } => write!(f, "{}", table_row),
+            Block::Template { template } => write!(f, "{}", template),
+            Block::ToDo { to_do } => write!(f, "{}", to_do),
+            Block::Toggle { toggle } => write!(f, "{}", toggle),
+            Block::Video { video } => write!(f, "{}", video),
+            Block::Unknown(value) => write!(f, "{:?}", value),
+        }
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/numbered_list_item.rs
+++ b/src/block/numbered_list_item.rs
@@ -48,6 +48,19 @@ where
     }
 }
 
+impl std::fmt::Display for NumberedListItemBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| { t.to_string() })
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/paragraph.rs
+++ b/src/block/paragraph.rs
@@ -36,6 +36,19 @@ where
     }
 }
 
+impl std::fmt::Display for ParagraphBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| { t.to_string() })
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/quote.rs
+++ b/src/block/quote.rs
@@ -48,6 +48,19 @@ where
     }
 }
 
+impl std::fmt::Display for QuoteBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| { t.to_string() })
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/synced_block.rs
+++ b/src/block/synced_block.rs
@@ -59,6 +59,15 @@ where
     }
 }
 
+impl std::fmt::Display for SyncedBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self.synced_from {
+            Some(synced_from) => write!(f, "{}", synced_from.block_id),
+            None => write!(f, ""),
+        }
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/table.rs
+++ b/src/block/table.rs
@@ -61,6 +61,16 @@ impl From<u16> for TableBlock {
     }
 }
 
+impl std::fmt::Display for TableBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "TableBlock {{ table_width: {}, has_column_header: {}, has_row_header: {} }}",
+            self.table_width, self.has_column_header, self.has_row_header
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/table_row.rs
+++ b/src/block/table_row.rs
@@ -26,6 +26,19 @@ impl TableRowBlock {
     }
 }
 
+impl std::fmt::Display for TableRowBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.cells
+                .iter()
+                .map(|t| { t.iter().map(|t| t.to_string()).collect::<String>() })
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/template.rs
+++ b/src/block/template.rs
@@ -17,6 +17,19 @@ impl TemplateBlock {
     }
 }
 
+impl std::fmt::Display for TemplateBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<String>()
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/to_do.rs
+++ b/src/block/to_do.rs
@@ -45,6 +45,19 @@ where
     }
 }
 
+impl std::fmt::Display for ToDoBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<String>(),
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/block/toggle.rs
+++ b/src/block/toggle.rs
@@ -45,6 +45,19 @@ where
     }
 }
 
+impl std::fmt::Display for ToggleBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.rich_text
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<String>(),
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,3 @@ pub use crate::others::language::Language;
 pub use crate::others::rich_text::RichText;
 pub use crate::others::select::{Select, SelectColor, SelectGroup};
 pub use crate::user::{bot::*, person::*, User};
-
-pub trait ToPlainText {
-    fn to_plain_text(&self) -> String;
-}

--- a/src/others/file.rs
+++ b/src/others/file.rs
@@ -104,6 +104,15 @@ impl Default for File {
     }
 }
 
+impl std::fmt::Display for File {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            File::External(file) => write!(f, "{}", file),
+            File::Uploaded(file) => write!(f, "{}", file),
+        }
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // external

--- a/src/others/rich_text/mention.rs
+++ b/src/others/rich_text/mention.rs
@@ -13,17 +13,17 @@ pub enum Mention {
     User(UserMention),
 }
 
-impl crate::ToPlainText for Mention {
-    /// Convert Mention to a plain string
-    fn to_plain_text(&self) -> String {
+impl std::fmt::Display for Mention {
+    /// Display the mention.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Mention::Database(db) => db.to_plain_text(),
-            Mention::Date(date) => date.to_plain_text(),
-            Mention::LinkPreview(lp) => lp.to_plain_text(),
-            Mention::LinkMention(lm) => lm.to_plain_text(),
-            Mention::TemplateMention(tm) => tm.to_plain_text(),
-            Mention::Page(p) => p.to_plain_text(),
-            Mention::User(user) => user.user.to_plain_text(),
+            Mention::Database(db) => write!(f, "{}", db),
+            Mention::Date(date) => write!(f, "{}", date),
+            Mention::LinkPreview(lp) => write!(f, "{}", lp),
+            Mention::LinkMention(lm) => write!(f, "{}", lm),
+            Mention::TemplateMention(tm) => write!(f, "{}", tm),
+            Mention::Page(p) => write!(f, "{}", p),
+            Mention::User(user) => write!(f, "{}", user),
         }
     }
 }
@@ -33,10 +33,10 @@ pub struct DatabaseMention {
     pub id: String,
 }
 
-impl crate::ToPlainText for DatabaseMention {
-    /// Convert DatabaseMention to a plain string
-    fn to_plain_text(&self) -> String {
-        self.id.clone()
+impl std::fmt::Display for DatabaseMention {
+    /// Display the database_id.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id)
     }
 }
 
@@ -45,10 +45,10 @@ pub struct LinkPreviewMention {
     pub url: String,
 }
 
-impl crate::ToPlainText for LinkPreviewMention {
-    /// Convert LinkPreviewMention to a plain string
-    fn to_plain_text(&self) -> String {
-        self.url.clone()
+impl std::fmt::Display for LinkPreviewMention {
+    /// Display the url.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.url)
     }
 }
 
@@ -64,10 +64,9 @@ pub struct LinkMentionMention {
     pub title: String,
 }
 
-impl crate::ToPlainText for LinkMentionMention {
-    /// Convert LinkMentionMention to a plain string
-    fn to_plain_text(&self) -> String {
-        self.title.clone()
+impl std::fmt::Display for LinkMentionMention {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.title)
     }
 }
 
@@ -76,10 +75,9 @@ pub struct PageMention {
     pub id: String,
 }
 
-impl crate::ToPlainText for PageMention {
-    /// Convert PageMention to a plain string
-    fn to_plain_text(&self) -> String {
-        self.id.clone()
+impl std::fmt::Display for PageMention {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id)
     }
 }
 
@@ -91,22 +89,16 @@ pub enum TemplateMention {
 }
 
 impl std::fmt::Display for TemplateMention {
+    /// Display the date or user if it exists.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TemplateMention::TemplateMentionDate(date) => {
-                write!(f, "template_mention_date: {}", date)
+                write!(f, "{}", date)
             }
             TemplateMention::TemplateMentionUser(user) => {
-                write!(f, "template_mention_user: {}", user)
+                write!(f, "{}", user)
             }
         }
-    }
-}
-
-impl crate::ToPlainText for TemplateMention {
-    /// Convert TemplateMention to a plain string
-    fn to_plain_text(&self) -> String {
-        self.to_string()
     }
 }
 
@@ -145,6 +137,12 @@ impl std::fmt::Display for TemplateMentionUser {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct UserMention {
     pub user: crate::User,
+}
+
+impl std::fmt::Display for UserMention {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.user)
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/others/rich_text/mod.rs
+++ b/src/others/rich_text/mod.rs
@@ -238,12 +238,12 @@ impl Default for RichText {
     }
 }
 
-impl crate::ToPlainText for RichText {
-    fn to_plain_text(&self) -> String {
+impl std::fmt::Display for RichText {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::Text { plain_text, .. } => plain_text.clone(),
-            Self::Mention { plain_text, .. } => plain_text.clone(),
-            Self::Equation { plain_text, .. } => plain_text.clone(),
+            Self::Text { plain_text, .. } => write!(f, "{}", plain_text),
+            Self::Mention { plain_text, .. } => write!(f, "{}", plain_text),
+            Self::Equation { plain_text, .. } => write!(f, "{}", plain_text),
         }
     }
 }

--- a/src/others/rich_text/mod.rs
+++ b/src/others/rich_text/mod.rs
@@ -248,18 +248,6 @@ impl std::fmt::Display for RichText {
     }
 }
 
-impl crate::ToPlainText for Vec<RichText> {
-    fn to_plain_text(&self) -> String {
-        self.iter()
-            .map(|rt| match rt {
-                RichText::Text { plain_text, .. } => plain_text.clone(),
-                RichText::Mention { plain_text, .. } => plain_text.clone(),
-                RichText::Equation { plain_text, .. } => plain_text.clone(),
-            })
-            .collect::<String>()
-    }
-}
-
 impl<T> From<T> for RichText
 where
     T: AsRef<str>,

--- a/src/others/rich_text/text.rs
+++ b/src/others/rich_text/text.rs
@@ -26,10 +26,9 @@ impl Text {
     }
 }
 
-impl crate::ToPlainText for Text {
-    /// Convert Text to a plain string
-    fn to_plain_text(&self) -> String {
-        self.content.clone()
+impl std::fmt::Display for Text {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.content)
     }
 }
 

--- a/src/others/select.rs
+++ b/src/others/select.rs
@@ -43,6 +43,12 @@ where
     }
 }
 
+impl std::fmt::Display for Select {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
 /// <https://developers.notion.com/reference/property-object#status>
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct SelectGroup {

--- a/src/page/properties/button.rs
+++ b/src/page/properties/button.rs
@@ -29,6 +29,12 @@ pub struct PageButtonProperty {
     pub button: std::collections::HashMap<String, String>,
 }
 
+impl std::fmt::Display for PageButtonProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "")
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/checkbox.rs
+++ b/src/page/properties/checkbox.rs
@@ -40,6 +40,13 @@ impl From<bool> for PageCheckboxProperty {
     }
 }
 
+impl std::fmt::Display for PageCheckboxProperty {
+    /// display the checkbox value as "Yes" if checked, "No" if unchecked
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", if self.checkbox { "Yes" } else { "No" })
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/created_by.rs
+++ b/src/page/properties/created_by.rs
@@ -44,6 +44,12 @@ pub struct PageCreatedByProperty {
     pub created_by: crate::user::User,
 }
 
+impl std::fmt::Display for PageCreatedByProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.created_by)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/created_time.rs
+++ b/src/page/properties/created_time.rs
@@ -29,8 +29,15 @@ pub struct PageCreatedTimeProperty {
     pub id: Option<String>,
 
     /// The date and time that the page was created.
-    ///The created_time value can’t be updated.
+    /// The created_time value can’t be updated.
     pub created_time: chrono::DateTime<chrono::FixedOffset>,
+}
+
+impl std::fmt::Display for PageCreatedTimeProperty {
+    /// display the created time in RFC3339 format
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.created_time.to_rfc3339())
+    }
 }
 
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/date.rs
+++ b/src/page/properties/date.rs
@@ -136,23 +136,21 @@ impl From<chrono::DateTime<chrono::FixedOffset>> for PageDateProperty {
     }
 }
 
-impl crate::ToPlainText for PageDateProperty {
-    /// Convert PageDateProperty to a plain string
-    fn to_plain_text(&self) -> String {
+impl std::fmt::Display for PageDateProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(date) = &self.date {
-            date.to_plain_text()
+            write!(f, "{}", date)
         } else {
-            String::new()
+            write!(f, "")
         }
     }
 }
 
-impl crate::ToPlainText for PageDatePropertyParameter {
-    /// Convert PageDatePropertyParameter to a plain string
-    fn to_plain_text(&self) -> String {
+impl std::fmt::Display for PageDatePropertyParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.start {
-            Some(start) => start.to_rfc3339(),
-            None => String::new(),
+            Some(start) => write!(f, "{}", start.to_rfc3339()),
+            None => write!(f, ""),
         }
     }
 }

--- a/src/page/properties/email.rs
+++ b/src/page/properties/email.rs
@@ -62,6 +62,13 @@ where
     }
 }
 
+impl std::fmt::Display for PageEmailProperty {
+    /// display the email address
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.email.as_deref().unwrap_or(""))
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/files.rs
+++ b/src/page/properties/files.rs
@@ -68,6 +68,21 @@ impl From<crate::File> for PageFilesProperty {
     }
 }
 
+impl std::fmt::Display for PageFilesProperty {
+    /// display the files' names in a comma-separated list
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.files
+                .iter()
+                .map(|file| file.to_string())
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/formula.rs
+++ b/src/page/properties/formula.rs
@@ -40,6 +40,12 @@ pub struct PageFormulaProperty {
     pub formula: Formula,
 }
 
+impl std::fmt::Display for PageFormulaProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.formula)
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Formula {
@@ -47,6 +53,17 @@ pub enum Formula {
     Date(FormulaDate),
     Number(FormulaNumber),
     String(FormulaString),
+}
+
+impl std::fmt::Display for Formula {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Formula::Boolean(b) => write!(f, "{}", b.boolean.unwrap_or(false)),
+            Formula::Date(d) => write!(f, "{}", d.date.unwrap_or_default()),
+            Formula::Number(n) => write!(f, "{}", n.number.unwrap_or(0.0)),
+            Formula::String(s) => write!(f, "{}", s.string.as_deref().unwrap_or("")),
+        }
+    }
 }
 
 /// ```json

--- a/src/page/properties/last_edited_by.rs
+++ b/src/page/properties/last_edited_by.rs
@@ -42,6 +42,12 @@ pub struct PageLastEditedByProperty {
     pub last_edited_by: crate::user::User,
 }
 
+impl std::fmt::Display for PageLastEditedByProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.last_edited_by)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/last_edited_time.rs
+++ b/src/page/properties/last_edited_time.rs
@@ -31,6 +31,13 @@ pub struct PageLastEditedTimeProperty {
     pub last_edited_time: chrono::DateTime<chrono::FixedOffset>,
 }
 
+impl std::fmt::Display for PageLastEditedTimeProperty {
+    /// Display
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.last_edited_time.to_rfc3339())
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/mod.rs
+++ b/src/page/properties/mod.rs
@@ -62,6 +62,35 @@ pub enum PageProperty {
     Url(url::PageUrlProperty),
 }
 
+impl std::fmt::Display for PageProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PageProperty::Button(button) => write!(f, "{}", button),
+            PageProperty::Checkbox(checkbox) => write!(f, "{}", checkbox),
+            PageProperty::CreatedBy(created_by) => write!(f, "{}", created_by),
+            PageProperty::CreatedTime(created_time) => write!(f, "{}", created_time),
+            PageProperty::Date(date) => write!(f, "{}", date),
+            PageProperty::Email(email) => write!(f, "{}", email),
+            PageProperty::Files(files) => write!(f, "{}", files),
+            PageProperty::Formula(formula) => write!(f, "{}", formula),
+            PageProperty::LastEditedBy(last_edited_by) => write!(f, "{}", last_edited_by),
+            PageProperty::LastEditedTime(last_edited_time) => write!(f, "{}", last_edited_time),
+            PageProperty::MultiSelect(multi_select) => write!(f, "{}", multi_select),
+            PageProperty::Number(number) => write!(f, "{}", number),
+            PageProperty::People(people) => write!(f, "{}", people),
+            PageProperty::PhoneNumber(phone_number) => write!(f, "{}", phone_number),
+            PageProperty::Relation(relation) => write!(f, "{}", relation),
+            PageProperty::RichText(rich_text) => write!(f, "{}", rich_text),
+            PageProperty::Rollup(rollup) => write!(f, "{}", rollup),
+            PageProperty::Select(select) => write!(f, "{}", select),
+            PageProperty::Status(status) => write!(f, "{}", status),
+            PageProperty::Title(title) => write!(f, "{}", title),
+            PageProperty::UniqueId(unique_id) => write!(f, "{}", unique_id),
+            PageProperty::Url(url) => write!(f, "{}", url),
+        }
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/multi_select.rs
+++ b/src/page/properties/multi_select.rs
@@ -49,6 +49,21 @@ impl PageMultiSelectProperty {
     }
 }
 
+impl std::fmt::Display for PageMultiSelectProperty {
+    /// Display
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.multi_select
+                .iter()
+                .map(|x| x.name.clone())
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/number.rs
+++ b/src/page/properties/number.rs
@@ -47,6 +47,12 @@ where
     }
 }
 
+impl std::fmt::Display for PageNumberProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.number.unwrap())
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/people.rs
+++ b/src/page/properties/people.rs
@@ -40,6 +40,21 @@ pub struct PagePeopleProperty {
     pub people: Vec<crate::user::User>,
 }
 
+impl std::fmt::Display for PagePeopleProperty {
+    /// Display user names or user IDs separated by commas
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.people
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/phone_number.rs
+++ b/src/page/properties/phone_number.rs
@@ -50,6 +50,12 @@ where
     }
 }
 
+impl std::fmt::Display for PagePhoneNumberProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.phone_number.as_ref().unwrap())
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/relation.rs
+++ b/src/page/properties/relation.rs
@@ -51,6 +51,21 @@ pub struct PageRelationPropertyParameter {
     pub id: String,
 }
 
+impl std::fmt::Display for PageRelationProperty {
+    /// Display
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.relation
+                .iter()
+                .map(|x| x.id.clone())
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/rich_text.rs
+++ b/src/page/properties/rich_text.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::ToPlainText;
-
 /// <https://developers.notion.com/reference/page-property-values#rich-text>
 ///
 /// - `$.['*'].id`: An underlying identifier for the property.
@@ -74,7 +72,11 @@ impl From<crate::RichText> for PageRichTextProperty {
 
 impl std::fmt::Display for PageRichTextProperty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let plain_text = self.rich_text.to_plain_text();
+        let plain_text = self
+            .rich_text
+            .iter()
+            .map(|rt| rt.to_string())
+            .collect::<String>();
         write!(f, "{}", plain_text)
     }
 }

--- a/src/page/properties/rollup.rs
+++ b/src/page/properties/rollup.rs
@@ -9,6 +9,12 @@ pub struct PageRollupProperty {
     pub id: Option<String>,
 }
 
+impl std::fmt::Display for PageRollupProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "")
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/select.rs
+++ b/src/page/properties/select.rs
@@ -52,6 +52,12 @@ where
     }
 }
 
+impl std::fmt::Display for PageSelectProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.select.as_ref().unwrap())
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/status.rs
+++ b/src/page/properties/status.rs
@@ -35,6 +35,12 @@ pub struct PageStatusProperty {
     pub status: crate::others::select::Select,
 }
 
+impl std::fmt::Display for PageStatusProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.status)
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/title.rs
+++ b/src/page/properties/title.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::ToPlainText;
-
 /// <https://developers.notion.com/reference/page-property-values#title>
 ///
 /// - `$.['*'].id`: An underlying identifier for the property.
@@ -74,7 +72,11 @@ impl From<crate::RichText> for PageTitleProperty {
 
 impl std::fmt::Display for PageTitleProperty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let plain_text = self.title.to_plain_text();
+        let plain_text = self
+            .title
+            .iter()
+            .map(|rt| rt.to_string())
+            .collect::<String>();
         write!(f, "{}", plain_text)
     }
 }

--- a/src/page/properties/unique_id.rs
+++ b/src/page/properties/unique_id.rs
@@ -46,6 +46,21 @@ pub struct PageUniqueIdPropertyParameter {
     pub number: u64,
 }
 
+impl std::fmt::Display for PageUniqueIdProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.unique_id)
+    }
+}
+
+impl std::fmt::Display for PageUniqueIdPropertyParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self.prefix {
+            Some(prefix) => write!(f, "{}-{}", prefix, self.number),
+            None => write!(f, "{}", self.number),
+        }
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/page/properties/url.rs
+++ b/src/page/properties/url.rs
@@ -50,6 +50,12 @@ where
     }
 }
 
+impl std::fmt::Display for PageUrlProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.url.as_ref().unwrap())
+    }
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test

--- a/src/user/bot.rs
+++ b/src/user/bot.rs
@@ -47,13 +47,13 @@ pub struct BotOwner {
     pub workspace: bool,
 }
 
-impl crate::ToPlainText for Bot {
-    /// Convert Bot to a plain string
-    fn to_plain_text(&self) -> String {
+impl std::fmt::Display for Bot {
+    /// Display the name if it exists, otherwise display the id.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(name) = &self.name {
-            name.clone()
+            write!(f, "{}", name)
         } else {
-            self.id.clone()
+            write!(f, "{}", self.id)
         }
     }
 }

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -13,12 +13,12 @@ pub enum User {
     Person(person::Person),
 }
 
-impl crate::ToPlainText for User {
-    /// Convert Bot to a plain string
-    fn to_plain_text(&self) -> String {
+impl std::fmt::Display for User {
+    /// Display the name if it exists, otherwise display the id.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Bot(bot) => bot.to_plain_text(),
-            Self::Person(person) => person.to_plain_text(),
+            Self::Bot(bot) => write!(f, "{}", bot),
+            Self::Person(person) => write!(f, "{}", person),
         }
     }
 }

--- a/src/user/person.rs
+++ b/src/user/person.rs
@@ -30,13 +30,13 @@ pub struct PersonDetail {
     pub email: Option<String>,
 }
 
-impl crate::ToPlainText for Person {
-    /// Convert Person to a plain string
-    fn to_plain_text(&self) -> String {
+impl std::fmt::Display for Person {
+    /// Display the name if it exists, otherwise display the id.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(name) = &self.name {
-            name.clone()
+            write!(f, "{}", name)
         } else {
-            self.id.clone()
+            write!(f, "{}", self.id)
         }
     }
 }


### PR DESCRIPTION
## Overview

- Replace `ToPlainText` with the `Display` trait.
- The functionality overlaps, so the standard trait is sufficient.

## Related Issues

N/A

## Changes

- Removed the existing `ToPlainText` trait.
- Implemented the `Display` trait for `PageProperty`.
- Implemented the `Display` trait for `Block`.

## Checklist

- [ ] The target branch for this PR is either `develop` or `release/*`.
- [ ] Unit tests have been added.
- [ ] All unit tests pass.
- [ ] Documentation has been updated if necessary.

## Additional Notes

N/A