### PR TITLE
Add update_page method to Client

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -137,6 +137,13 @@ impl Client {
         }
     }
 
+    pub fn update_page(&self) -> crate::client::page::update_page::UpdatePageClient {
+        crate::client::page::update_page::UpdatePageClient {
+            reqwest_client: self.reqwest_client.clone(),
+            ..Default::default()
+        }
+    }
+
     // # --------------------------------------------------------------------------------
     //
     // Database


### PR DESCRIPTION
Introduce the `update_page` method to the Client, enabling the creation of an `UpdatePageClient` instance with the existing `reqwest_client`.