### PR TITLE
fix(color): add DefaultBackground variant to Color enum

### DIFF
--- a/src/others/color.rs
+++ b/src/others/color.rs
@@ -16,6 +16,8 @@ pub enum Color {
     Red,
     Yellow,
 
+    DefaultBackground,
+
     BlueBackground,
     BrownBackground,
     GrayBackground,


### PR DESCRIPTION
## Overview

- fix deserialization error

## Related Issues

- makenotion/notion-sdk-js#536

## Changes

- Add `DefaultBackground` to enum `Color`.

## Checklist

- [ ] The target branch for this PR is either `develop` or `release/*`.
- [ ] Unit tests have been added.
- [ ] All unit tests pass.
- [ ] Documentation has been updated if necessary.

## Additional Notes

N/A
