### PR TITLE
Add Expired state to PageVerificationState enum

### DIFF
--- a/src/page/properties/verification.rs
+++ b/src/page/properties/verification.rs
@@ -39,6 +39,7 @@ pub enum PageVerificationState {
     Verified,
     #[default]
     Unverified,
+    Expired,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
@@ -109,6 +110,7 @@ impl std::fmt::Display for PageVerificationProperty {
             match self.verification.state {
                 PageVerificationState::Verified => "verified",
                 PageVerificationState::Unverified => "unverified",
+                PageVerificationState::Expired => "expired",
             }
         )
     }


### PR DESCRIPTION
## Overview

Add `Expired `variant to `PageVerificationState `enum. 

## Related Issues

- Fix #119

## Changes

- Add `Expired `variant to `PageVerificationState `enum. 

## Checklist

- [ ] The target branch for this PR is either `develop` or `release/*`.
- [ ] Unit tests have been added.
- [ ] All unit tests pass.
- [ ] Documentation has been updated if necessary.

## Additional Notes

N/A
