### PR TITLE
Update Emoji struct to use String and add deserialization test for page icon emoji

### DIFF
--- a/src/block/callout.rs
+++ b/src/block/callout.rs
@@ -121,7 +121,7 @@ mod unit_tests {
         match callout.icon {
             crate::others::icon::Icon::Emoji(emoji) => {
                 assert_eq!(emoji.r#type, "emoji");
-                assert_eq!(emoji.emoji, '💡');
+                assert_eq!(emoji.emoji, "💡".to_string());
             }
             _ => panic!("Unexpected!"),
         };

--- a/src/others/emoji.rs
+++ b/src/others/emoji.rs
@@ -7,11 +7,11 @@ pub struct Emoji {
     pub r#type: String,
 
     /// The emoji character. For example, "😻".
-    pub emoji: char,
+    pub emoji: String,
 }
 
 impl Emoji {
-    pub fn emoji(mut self, emoji: char) -> Self {
+    pub fn emoji(mut self, emoji: String) -> Self {
         self.emoji = emoji;
         self
     }
@@ -23,15 +23,18 @@ impl Default for Emoji {
     fn default() -> Self {
         Emoji {
             r#type: "emoji".to_string(),
-            emoji: '💡',
+            emoji: '💡'.to_string(),
         }
     }
 }
 
-impl From<char> for Emoji {
+impl<T> From<T> for Emoji
+where
+    T: AsRef<str>,
+{
     /// Convert from a char to an Emoji.
-    fn from(value: char) -> Self {
-        Self::default().emoji(value)
+    fn from(value: T) -> Self {
+        Self::default().emoji(value.as_ref().to_string())
     }
 }
 
@@ -55,23 +58,23 @@ mod tests {
     fn test_emoji_default() {
         let emoji = Emoji::default();
         assert_eq!(emoji.r#type, "emoji");
-        assert_eq!(emoji.emoji, '💡');
+        assert_eq!(emoji.emoji, "💡".to_string());
         assert_eq!(emoji.to_string(), "💡");
     }
 
     #[test]
     fn test_emoji_from() {
-        let emoji = Emoji::from('🔥');
+        let emoji = Emoji::from("🔥");
         assert_eq!(emoji.r#type, "emoji");
-        assert_eq!(emoji.emoji, '🔥');
+        assert_eq!(emoji.emoji, "🔥".to_string());
         assert_eq!(emoji.to_string(), "🔥");
     }
 
     #[test]
     fn test_emoji_into() {
-        let emoji: Emoji = '🔥'.into();
+        let emoji = Emoji::from("🔥");
         assert_eq!(emoji.r#type, "emoji");
-        assert_eq!(emoji.emoji, '🔥');
+        assert_eq!(emoji.emoji, "🔥".to_string());
         assert_eq!(emoji.to_string(), "🔥");
     }
 

--- a/src/page/page_response.rs
+++ b/src/page/page_response.rs
@@ -49,4 +49,12 @@ mod tests {
         let _page = serde_json::from_str::<crate::page::PageResponse>(json_data)
             .expect("An error occurred while deserializing the page");
     }
+
+    #[test]
+    fn deserialize_page_icon_emoji() {
+        let json_data = include_str!("./seeds/page_icon_emoji.json");
+
+        let _page = serde_json::from_str::<crate::page::PageResponse>(json_data)
+            .expect("An error occurred while deserializing the page");
+    }
 }

--- a/src/page/seeds/page_icon_emoji.json
+++ b/src/page/seeds/page_icon_emoji.json
@@ -1,0 +1,77 @@
+{
+  "object": "page",
+  "id": "****",
+  "created_time": "2024-12-27T19:03:00.000Z",
+  "last_edited_time": "2024-12-27T19:11:00.000Z",
+  "created_by": {
+    "object": "user",
+    "id": "****"
+  },
+  "last_edited_by": {
+    "object": "user",
+    "id": "****"
+  },
+  "cover": null,
+  "icon": {
+    "type": "emoji",
+    "emoji": "♻️"
+  },
+  "parent": {
+    "type": "database_id",
+    "database_id": "****"
+  },
+  "archived": false,
+  "in_trash": false,
+  "properties": {
+    "IsDone": {
+      "id": "%3F%5C%7Cx",
+      "type": "checkbox",
+      "checkbox": false
+    },
+    "DayOfTheWeek": {
+      "id": "K%5CH%7B",
+      "type": "multi_select",
+      "multi_select": [
+        {
+          "id": "m?[\\",
+          "name": "Tuesday",
+          "color": "gray"
+        }
+      ]
+    },
+    "DayType": {
+      "id": "cJ%5CE",
+      "type": "select",
+      "select": {
+        "id": "|gp<",
+        "name": "Everyday",
+        "color": "green"
+      }
+    },
+    "Name": {
+      "id": "title",
+      "type": "title",
+      "title": [
+        {
+          "type": "text",
+          "text": {
+            "content": "Collection",
+            "link": null
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "Collection",
+          "href": null
+        }
+      ]
+    }
+  },
+  "url": "https://www.notion.so/uuid",
+  "public_url": null
+}

--- a/tests/database/create_database.rs
+++ b/tests/database/create_database.rs
@@ -154,7 +154,7 @@ mod integration_tests {
                 "Description of the Database",
             )])
             .properties(properties)
-            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from('🚧')))
+            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from("🚧")))
             .cover(notionrs::File::External(notionrs::ExternalFile::from(
                 "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
             )));

--- a/tests/database/update_database.rs
+++ b/tests/database/update_database.rs
@@ -186,7 +186,7 @@ mod integration_tests {
                 "Description of the Database (changed)",
             )])
             .properties(properties)
-            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from('🚧')))
+            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from("🚧")))
             .cover(notionrs::File::External(notionrs::ExternalFile::from(
                 "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
             )));

--- a/tests/page/crud_page.rs
+++ b/tests/page/crud_page.rs
@@ -31,7 +31,7 @@ mod integration_tests {
             .create_page()
             .properties(properties)
             .page_id(page_id)
-            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from('🚧')))
+            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from("🚧")))
             .cover(notionrs::File::External(notionrs::ExternalFile::from(
                 "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
             )));

--- a/tests/page/crud_page_with_database.rs
+++ b/tests/page/crud_page_with_database.rs
@@ -119,7 +119,7 @@ mod integration_tests {
                 "Description of the Database",
             )])
             .properties(properties)
-            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from('🚧')))
+            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from("🚧")))
             .cover(notionrs::File::External(notionrs::ExternalFile::from(
                 "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
             )));
@@ -213,7 +213,7 @@ mod integration_tests {
             .create_page()
             .properties(properties)
             .database_id(response.id)
-            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from('🚧')))
+            .icon(notionrs::Icon::Emoji(notionrs::Emoji::from("🚧")))
             .cover(notionrs::File::External(notionrs::ExternalFile::from(
                 "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
             )));


### PR DESCRIPTION
Refactor the Emoji struct to represent emojis as Strings instead of chars, enhancing compatibility with JSON deserialization. Add a test to verify the deserialization of a page icon emoji from JSON data.