### PR TITLE
Add Clone derive to response and property structs

### DIFF
--- a/src/block/code.rs
+++ b/src/block/code.rs
@@ -94,7 +94,7 @@ mod unit_tests {
                 {
                     "type": "text",
                     "text": {
-                        "content": "use serde::{Deserialize, Serialize};\n\n#[derive(Debug, Deserialize, Serialize)]\npub struct Emoji {\n    pub r#type: String,\n    pub emoji: String,\n}",
+                        "content": "use serde::{Deserialize, Serialize};\n\n#[derive(Debug, Deserialize, Serialize, Clone)]\npub struct Emoji {\n    pub r#type: String,\n    pub emoji: String,\n}",
                         "link": null
                     },
                     "annotations": {
@@ -105,7 +105,7 @@ mod unit_tests {
                         "code": false,
                         "color": "default"
                     },
-                    "plain_text": "use serde::{Deserialize, Serialize};\n\n#[derive(Debug, Deserialize, Serialize)]\npub struct Emoji {\n    pub r#type: String,\n    pub emoji: String,\n}",
+                    "plain_text": "use serde::{Deserialize, Serialize};\n\n#[derive(Debug, Deserialize, Serialize, Clone)]\npub struct Emoji {\n    pub r#type: String,\n    pub emoji: String,\n}",
                     "href": null
                 }
             ],

--- a/src/database/database_response.rs
+++ b/src/database/database_response.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseResponse {
     pub id: String,
 

--- a/src/database/properties/mod.rs
+++ b/src/database/properties/mod.rs
@@ -37,7 +37,7 @@ pub use {
     unique_id::DatabaseUniqueIdProperty, url::DatabaseUrlProperty,
 };
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum DatabaseProperty {
     Button(button::DatabaseButtonProperty),

--- a/src/error/api_error.rs
+++ b/src/error/api_error.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 ///     "request_id": "2cccb738-bf60-4e9b-bb6b-24a87fb17ef3"
 /// }
 /// ```
-#[derive(Error, Debug, Deserialize, Serialize)]
+#[derive(Error, Debug, Deserialize, Serialize, Clone)]
 #[error("Notion API error: status {status}, code: {code}, message: {message}")]
 pub struct ApiError {
     /// always "error"

--- a/src/list_response.rs
+++ b/src/list_response.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone)]
 pub struct ListResponse<T> {
     /// always "list"
     pub object: String,
@@ -11,7 +11,7 @@ pub struct ListResponse<T> {
     pub r#type: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "object", rename_all = "snake_case")]
 pub enum SearchResultItem {
     Page(crate::page::PageResponse),

--- a/src/others/file.rs
+++ b/src/others/file.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum File {
     External(ExternalFile),
@@ -121,7 +121,7 @@ impl Default for File {
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ExternalFile {
     /// always "external"
     // An error occurs if this field is present when calling the block creation API.
@@ -140,7 +140,7 @@ pub struct ExternalFile {
     pub caption: Option<Vec<crate::others::rich_text::RichText>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 pub struct ExternalFileParameter {
     /// URL of the file
     pub url: String,
@@ -211,7 +211,7 @@ impl std::fmt::Display for ExternalFileParameter {
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct UploadedFile {
     /// always "file"
     pub r#type: String,
@@ -233,7 +233,7 @@ impl std::fmt::Display for UploadedFile {
 }
 
 /// file
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct UploadedFileParameter {
     /// Signed URL for the file (Amazon S3)
     pub url: String,

--- a/src/others/parent.rs
+++ b/src/others/parent.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// <https://developers.notion.com/reference/parent-object>
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
 pub enum Parent {
     DatabaseParent(DatabaseParent),
@@ -11,7 +11,7 @@ pub enum Parent {
 }
 
 /// <https://developers.notion.com/reference/parent-object#database-parent>
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct DatabaseParent {
     /// always "database_id"
     pub r#type: String,
@@ -37,7 +37,7 @@ impl From<String> for DatabaseParent {
 }
 
 /// <https://developers.notion.com/reference/parent-object#page-parent>
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct PageParent {
     /// always "page_id"
     pub r#type: String,
@@ -63,7 +63,7 @@ impl From<String> for PageParent {
 }
 
 /// <https://developers.notion.com/reference/parent-object#workspace-parent>
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct WorkspaceParent {
     /// always "workspace"
     pub r#type: String,
@@ -72,7 +72,7 @@ pub struct WorkspaceParent {
 }
 
 /// <https://developers.notion.com/reference/parent-object#block-parent>
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct BlockParent {
     /// always "block_id"
     pub r#type: String,

--- a/src/page/page_response.rs
+++ b/src/page/page_response.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// <https://developers.notion.com/reference/page>
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageResponse {
     pub id: String,
     pub created_time: chrono::DateTime<chrono::FixedOffset>,

--- a/src/page/properties/button.rs
+++ b/src/page/properties/button.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageButtonProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/checkbox.rs
+++ b/src/page/properties/checkbox.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageCheckboxProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/created_by.rs
+++ b/src/page/properties/created_by.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageCreatedByProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/created_time.rs
+++ b/src/page/properties/created_time.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageCreatedTimeProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/date.rs
+++ b/src/page/properties/date.rs
@@ -41,7 +41,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct PageDateProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -53,7 +53,7 @@ pub struct PageDateProperty {
 }
 
 /// If the value is blank, it will be an empty object.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct PageDatePropertyParameter {
     /// A date, with an optional time.
     #[serde(deserialize_with = "deserialize_date_or_datetime")]

--- a/src/page/properties/email.rs
+++ b/src/page/properties/email.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageEmailProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/files.rs
+++ b/src/page/properties/files.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageFilesProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/formula.rs
+++ b/src/page/properties/formula.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageFormulaProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -46,7 +46,7 @@ impl std::fmt::Display for PageFormulaProperty {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Formula {
     Boolean(FormulaBoolean),

--- a/src/page/properties/last_edited_by.rs
+++ b/src/page/properties/last_edited_by.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageLastEditedByProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/last_edited_time.rs
+++ b/src/page/properties/last_edited_time.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageLastEditedTimeProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/mod.rs
+++ b/src/page/properties/mod.rs
@@ -36,7 +36,7 @@ pub use {
     url::PageUrlProperty, verification::PageVerificationProperty,
 };
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PageProperty {
     Button(button::PageButtonProperty),

--- a/src/page/properties/multi_select.rs
+++ b/src/page/properties/multi_select.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageMultiSelectProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/number.rs
+++ b/src/page/properties/number.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageNumberProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/people.rs
+++ b/src/page/properties/people.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PagePeopleProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/phone_number.rs
+++ b/src/page/properties/phone_number.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PagePhoneNumberProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/relation.rs
+++ b/src/page/properties/relation.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRelationProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -45,7 +45,7 @@ pub struct PageRelationProperty {
     pub has_more: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRelationPropertyParameter {
     /// related page id
     pub id: String,

--- a/src/page/properties/rich_text.rs
+++ b/src/page/properties/rich_text.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRichTextProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/rollup.rs
+++ b/src/page/properties/rollup.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 // TODO: Implement the Rollup object.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRollupProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/select.rs
+++ b/src/page/properties/select.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageSelectProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/status.rs
+++ b/src/page/properties/status.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageStatusProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/title.rs
+++ b/src/page/properties/title.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 pub struct PageTitleProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/unique_id.rs
+++ b/src/page/properties/unique_id.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageUniqueIdProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -36,7 +36,7 @@ pub struct PageUniqueIdProperty {
 
 /// Unique IDs can be read using the API with a GET page request,
 /// but they cannot be updated with the API, since they are auto-incrementing.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageUniqueIdPropertyParameter {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/url.rs
+++ b/src/page/properties/url.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageUrlProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/verification.rs
+++ b/src/page/properties/verification.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 ///
 /// **Note**: The `['*']` part represents the column name you set when creating the database.
 ///
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageVerificationProperty {
     #[serde(skip_serializing)]
     pub id: Option<String>,
@@ -23,7 +23,7 @@ pub struct PageVerificationProperty {
     pub verification: PageVerificationPropertyParameter,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageVerificationPropertyParameter {
     /// The verification state of the page. `"verified"` or `"unverified"`.
     pub state: PageVerificationState,
@@ -42,7 +42,7 @@ pub enum PageVerificationState {
     Expired,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct PageVerificationDate {
     /// A date, with an optional time.
     #[serde(deserialize_with = "deserialize_date_or_datetime")]

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -6,7 +6,7 @@ pub mod bot;
 /// User objects that represent people have the type property set to "person".
 pub mod person;
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum User {
     Bot(bot::Bot),

--- a/src/user/person.rs
+++ b/src/user/person.rs
@@ -23,7 +23,7 @@ pub struct Person {
     pub person: Option<PersonDetail>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct PersonDetail {
     /// Email address of person. This is only present if an integration has
     /// user capabilities that allow access to email addresses.


### PR DESCRIPTION
Introduce the Clone derive to various response and property structs to enhance their usability and facilitate easier cloning of instances.