### PR TITLE
Update dependencies and add Clone derive to structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-alpha.29"
+version = "1.0.0-alpha.30"
 dependencies = [
  "chrono",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-alpha.29"
+version = "1.0.0-alpha.30"
 edition = "2021"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 chrono = { version = "0.4.39", features = ["serde"] }
 reqwest = { version = "0.12.12", default-features = false }
 serde = { version = "1.0.217", features = ["derive"] }
-serde_json = "1.0.137"
+serde_json = "1.0.138"
 thiserror = "2.0.11"
 
 [dev-dependencies]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "posttest": "npm run test:cleanup"
     },
     "devDependencies": {
-        "@types/node": "^22.10.10",
+        "@types/node": "^22.12.0",
         "dotenv": "^16.4.7",
         "prettier": "^3.4.2",
         "tsx": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "posttest": "npm run test:cleanup"
     },
     "devDependencies": {
-        "@types/node": "^22.10.8",
+        "@types/node": "^22.10.10",
         "dotenv": "^16.4.7",
         "prettier": "^3.4.2",
         "tsx": "^4.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 2.2.15
     devDependencies:
       '@types/node':
-        specifier: ^22.10.8
-        version: 22.10.8
+        specifier: ^22.10.10
+        version: 22.10.10
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -29,7 +29,7 @@ importers:
         version: 5.7.3
       vitepress:
         specifier: ^1.6.3
-        version: 1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.8)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.7.3)
+        version: 1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.10)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.7.3)
 
 packages:
 
@@ -580,8 +580,8 @@ packages:
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
 
-  '@types/node@22.10.8':
-    resolution: {integrity: sha512-rk+QvAEGsbX/ZPiiyel6hJHNUS9cnSbPWVaZLvE+Er3tLqQFzWMz9JOfWW7XUmKvRPfxJfbl3qYWve+RGXncFw==}
+  '@types/node@22.10.10':
+    resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1427,10 +1427,10 @@ snapshots:
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 22.10.8
+      '@types/node': 22.10.10
       form-data: 4.0.1
 
-  '@types/node@22.10.8':
+  '@types/node@22.10.10':
     dependencies:
       undici-types: 6.20.0
 
@@ -1440,9 +1440,9 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.10.8))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.10.10))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 5.4.14(@types/node@22.10.8)
+      vite: 5.4.14(@types/node@22.10.10)
       vue: 3.5.13(typescript@5.7.3)
 
   '@vue/compiler-core@3.5.13':
@@ -1883,16 +1883,16 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@5.4.14(@types/node@22.10.8):
+  vite@5.4.14(@types/node@22.10.10):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.31.0
     optionalDependencies:
-      '@types/node': 22.10.8
+      '@types/node': 22.10.10
       fsevents: 2.3.3
 
-  vitepress@1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.8)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.7.3):
+  vitepress@1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.10)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.7.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.20.0)(search-insights@2.17.2)
@@ -1901,7 +1901,7 @@ snapshots:
       '@shikijs/transformers': 2.1.0
       '@shikijs/types': 2.1.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@22.10.8))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@22.10.10))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-api': 7.7.0
       '@vue/shared': 3.5.13
       '@vueuse/core': 12.5.0(typescript@5.7.3)
@@ -1910,7 +1910,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.1
       shiki: 2.1.0
-      vite: 5.4.14(@types/node@22.10.8)
+      vite: 5.4.14(@types/node@22.10.10)
       vue: 3.5.13(typescript@5.7.3)
     optionalDependencies:
       postcss: 8.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 2.2.15
     devDependencies:
       '@types/node':
-        specifier: ^22.10.10
-        version: 22.10.10
+        specifier: ^22.12.0
+        version: 22.12.0
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -29,7 +29,7 @@ importers:
         version: 5.7.3
       vitepress:
         specifier: ^1.6.3
-        version: 1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.10)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.7.3)
+        version: 1.6.3(@algolia/client-search@5.20.0)(@types/node@22.12.0)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.7.3)
 
 packages:
 
@@ -580,8 +580,8 @@ packages:
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
 
-  '@types/node@22.10.10':
-    resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
+  '@types/node@22.12.0':
+    resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1427,10 +1427,10 @@ snapshots:
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 22.12.0
       form-data: 4.0.1
 
-  '@types/node@22.10.10':
+  '@types/node@22.12.0':
     dependencies:
       undici-types: 6.20.0
 
@@ -1440,9 +1440,9 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.10.10))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 5.4.14(@types/node@22.10.10)
+      vite: 5.4.14(@types/node@22.12.0)
       vue: 3.5.13(typescript@5.7.3)
 
   '@vue/compiler-core@3.5.13':
@@ -1883,16 +1883,16 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@5.4.14(@types/node@22.10.10):
+  vite@5.4.14(@types/node@22.12.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.31.0
     optionalDependencies:
-      '@types/node': 22.10.10
+      '@types/node': 22.12.0
       fsevents: 2.3.3
 
-  vitepress@1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.10)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.7.3):
+  vitepress@1.6.3(@algolia/client-search@5.20.0)(@types/node@22.12.0)(postcss@8.5.1)(search-insights@2.17.2)(typescript@5.7.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.20.0)(search-insights@2.17.2)
@@ -1901,7 +1901,7 @@ snapshots:
       '@shikijs/transformers': 2.1.0
       '@shikijs/types': 2.1.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@22.10.10))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-api': 7.7.0
       '@vue/shared': 3.5.13
       '@vueuse/core': 12.5.0(typescript@5.7.3)
@@ -1910,7 +1910,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.1
       shiki: 2.1.0
-      vite: 5.4.14(@types/node@22.10.10)
+      vite: 5.4.14(@types/node@22.12.0)
       vue: 3.5.13(typescript@5.7.3)
     optionalDependencies:
       postcss: 8.5.1

--- a/src/block/code.rs
+++ b/src/block/code.rs
@@ -94,7 +94,7 @@ mod unit_tests {
                 {
                     "type": "text",
                     "text": {
-                        "content": "use serde::{Deserialize, Serialize};\n\n#[derive(Debug, Deserialize, Serialize)]\npub struct Emoji {\n    pub r#type: String,\n    pub emoji: String,\n}",
+                        "content": "use serde::{Deserialize, Serialize};\n\n#[derive(Debug, Deserialize, Serialize, Clone)]\npub struct Emoji {\n    pub r#type: String,\n    pub emoji: String,\n}",
                         "link": null
                     },
                     "annotations": {
@@ -105,7 +105,7 @@ mod unit_tests {
                         "code": false,
                         "color": "default"
                     },
-                    "plain_text": "use serde::{Deserialize, Serialize};\n\n#[derive(Debug, Deserialize, Serialize)]\npub struct Emoji {\n    pub r#type: String,\n    pub emoji: String,\n}",
+                    "plain_text": "use serde::{Deserialize, Serialize};\n\n#[derive(Debug, Deserialize, Serialize, Clone)]\npub struct Emoji {\n    pub r#type: String,\n    pub emoji: String,\n}",
                     "href": null
                 }
             ],

--- a/src/database/database_response.rs
+++ b/src/database/database_response.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseResponse {
     pub id: String,
 

--- a/src/database/properties/mod.rs
+++ b/src/database/properties/mod.rs
@@ -37,7 +37,7 @@ pub use {
     unique_id::DatabaseUniqueIdProperty, url::DatabaseUrlProperty,
 };
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum DatabaseProperty {
     Button(button::DatabaseButtonProperty),

--- a/src/error/api_error.rs
+++ b/src/error/api_error.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 ///     "request_id": "2cccb738-bf60-4e9b-bb6b-24a87fb17ef3"
 /// }
 /// ```
-#[derive(Error, Debug, Deserialize, Serialize)]
+#[derive(Error, Debug, Deserialize, Serialize, Clone)]
 #[error("Notion API error: status {status}, code: {code}, message: {message}")]
 pub struct ApiError {
     /// always "error"

--- a/src/list_response.rs
+++ b/src/list_response.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Default, Deserialize, Serialize, Debug, Clone)]
 pub struct ListResponse<T> {
     /// always "list"
     pub object: String,
@@ -11,7 +11,7 @@ pub struct ListResponse<T> {
     pub r#type: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "object", rename_all = "snake_case")]
 pub enum SearchResultItem {
     Page(crate::page::PageResponse),

--- a/src/others/file.rs
+++ b/src/others/file.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum File {
     External(ExternalFile),
@@ -121,7 +121,7 @@ impl Default for File {
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ExternalFile {
     /// always "external"
     // An error occurs if this field is present when calling the block creation API.
@@ -140,7 +140,7 @@ pub struct ExternalFile {
     pub caption: Option<Vec<crate::others::rich_text::RichText>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 pub struct ExternalFileParameter {
     /// URL of the file
     pub url: String,
@@ -211,7 +211,7 @@ impl std::fmt::Display for ExternalFileParameter {
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct UploadedFile {
     /// always "file"
     pub r#type: String,
@@ -233,7 +233,7 @@ impl std::fmt::Display for UploadedFile {
 }
 
 /// file
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct UploadedFileParameter {
     /// Signed URL for the file (Amazon S3)
     pub url: String,

--- a/src/others/parent.rs
+++ b/src/others/parent.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// <https://developers.notion.com/reference/parent-object>
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
 pub enum Parent {
     DatabaseParent(DatabaseParent),
@@ -11,7 +11,7 @@ pub enum Parent {
 }
 
 /// <https://developers.notion.com/reference/parent-object#database-parent>
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct DatabaseParent {
     /// always "database_id"
     pub r#type: String,
@@ -37,7 +37,7 @@ impl From<String> for DatabaseParent {
 }
 
 /// <https://developers.notion.com/reference/parent-object#page-parent>
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct PageParent {
     /// always "page_id"
     pub r#type: String,
@@ -63,7 +63,7 @@ impl From<String> for PageParent {
 }
 
 /// <https://developers.notion.com/reference/parent-object#workspace-parent>
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct WorkspaceParent {
     /// always "workspace"
     pub r#type: String,
@@ -72,7 +72,7 @@ pub struct WorkspaceParent {
 }
 
 /// <https://developers.notion.com/reference/parent-object#block-parent>
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct BlockParent {
     /// always "block_id"
     pub r#type: String,

--- a/src/page/page_response.rs
+++ b/src/page/page_response.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// <https://developers.notion.com/reference/page>
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageResponse {
     pub id: String,
     pub created_time: chrono::DateTime<chrono::FixedOffset>,

--- a/src/page/properties/button.rs
+++ b/src/page/properties/button.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageButtonProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/checkbox.rs
+++ b/src/page/properties/checkbox.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageCheckboxProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/created_by.rs
+++ b/src/page/properties/created_by.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageCreatedByProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/created_time.rs
+++ b/src/page/properties/created_time.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageCreatedTimeProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/date.rs
+++ b/src/page/properties/date.rs
@@ -41,7 +41,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct PageDateProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -53,7 +53,7 @@ pub struct PageDateProperty {
 }
 
 /// If the value is blank, it will be an empty object.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct PageDatePropertyParameter {
     /// A date, with an optional time.
     #[serde(deserialize_with = "deserialize_date_or_datetime")]

--- a/src/page/properties/email.rs
+++ b/src/page/properties/email.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageEmailProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/files.rs
+++ b/src/page/properties/files.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageFilesProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/formula.rs
+++ b/src/page/properties/formula.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageFormulaProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -46,7 +46,7 @@ impl std::fmt::Display for PageFormulaProperty {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Formula {
     Boolean(FormulaBoolean),

--- a/src/page/properties/last_edited_by.rs
+++ b/src/page/properties/last_edited_by.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageLastEditedByProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/last_edited_time.rs
+++ b/src/page/properties/last_edited_time.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageLastEditedTimeProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/mod.rs
+++ b/src/page/properties/mod.rs
@@ -36,7 +36,7 @@ pub use {
     url::PageUrlProperty, verification::PageVerificationProperty,
 };
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PageProperty {
     Button(button::PageButtonProperty),

--- a/src/page/properties/multi_select.rs
+++ b/src/page/properties/multi_select.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageMultiSelectProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/number.rs
+++ b/src/page/properties/number.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageNumberProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/people.rs
+++ b/src/page/properties/people.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PagePeopleProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/phone_number.rs
+++ b/src/page/properties/phone_number.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PagePhoneNumberProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/relation.rs
+++ b/src/page/properties/relation.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRelationProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -45,7 +45,7 @@ pub struct PageRelationProperty {
     pub has_more: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRelationPropertyParameter {
     /// related page id
     pub id: String,

--- a/src/page/properties/rich_text.rs
+++ b/src/page/properties/rich_text.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRichTextProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/rollup.rs
+++ b/src/page/properties/rollup.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 // TODO: Implement the Rollup object.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRollupProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/select.rs
+++ b/src/page/properties/select.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageSelectProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/status.rs
+++ b/src/page/properties/status.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageStatusProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/title.rs
+++ b/src/page/properties/title.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 pub struct PageTitleProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/unique_id.rs
+++ b/src/page/properties/unique_id.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageUniqueIdProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -36,7 +36,7 @@ pub struct PageUniqueIdProperty {
 
 /// Unique IDs can be read using the API with a GET page request,
 /// but they cannot be updated with the API, since they are auto-incrementing.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageUniqueIdPropertyParameter {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/url.rs
+++ b/src/page/properties/url.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageUrlProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.

--- a/src/page/properties/verification.rs
+++ b/src/page/properties/verification.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 ///
 /// **Note**: The `['*']` part represents the column name you set when creating the database.
 ///
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageVerificationProperty {
     #[serde(skip_serializing)]
     pub id: Option<String>,
@@ -23,7 +23,7 @@ pub struct PageVerificationProperty {
     pub verification: PageVerificationPropertyParameter,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PageVerificationPropertyParameter {
     /// The verification state of the page. `"verified"` or `"unverified"`.
     pub state: PageVerificationState,
@@ -42,7 +42,7 @@ pub enum PageVerificationState {
     Expired,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct PageVerificationDate {
     /// A date, with an optional time.
     #[serde(deserialize_with = "deserialize_date_or_datetime")]

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -6,7 +6,7 @@ pub mod bot;
 /// User objects that represent people have the type property set to "person".
 pub mod person;
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum User {
     Bot(bot::Bot),

--- a/src/user/person.rs
+++ b/src/user/person.rs
@@ -23,7 +23,7 @@ pub struct Person {
     pub person: Option<PersonDetail>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct PersonDetail {
     /// Email address of person. This is only present if an integration has
     /// user capabilities that allow access to email addresses.


### PR DESCRIPTION
Bump various dependencies, including `@types/node` and `serde_json`, and add the `Clone` derive to multiple response and property structs for improved usability.