### PR TITLE
Refactor API response handling to use bytes and from_slice

### DIFF
--- a/src/client/block/append_block_children.rs
+++ b/src/client/block/append_block_children.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::error::{api_error::ApiError, Error};
+use crate::error::{Error, api_error::ApiError};
 
 #[derive(Debug)]
 pub struct AppendBlockChildrenClient {
@@ -31,11 +31,9 @@ impl AppendBlockChildrenClient {
     pub async fn send(
         self,
     ) -> Result<crate::list_response::ListResponse<crate::block::BlockResponse>, Error> {
-        let block_id = self
-            .block_id
-            .ok_or(Error::RequestParameter(
-                "`block_id` has not been set.".to_string(),
-            ))?;
+        let block_id = self.block_id.ok_or(Error::RequestParameter(
+            "`block_id` has not been set.".to_string(),
+        ))?;
 
         let request_body_struct = AppendBlockChildrenRequestBody {
             children: self.children,
@@ -55,16 +53,16 @@ impl AppendBlockChildrenClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let block = serde_json::from_str::<
+        let block = serde_json::from_slice::<
             crate::list_response::ListResponse<crate::block::BlockResponse>,
         >(&body)?;
 

--- a/src/client/block/delete_block.rs
+++ b/src/client/block/delete_block.rs
@@ -1,4 +1,4 @@
-use crate::error::{api_error::ApiError, Error};
+use crate::error::{Error, api_error::ApiError};
 
 #[derive(Debug)]
 pub struct DeleteBlockClient {
@@ -22,16 +22,16 @@ impl DeleteBlockClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let block = serde_json::from_str::<crate::block::BlockResponse>(&body)?;
+        let block = serde_json::from_slice::<crate::block::BlockResponse>(&body)?;
 
         Ok(block)
     }

--- a/src/client/block/get_block.rs
+++ b/src/client/block/get_block.rs
@@ -1,4 +1,4 @@
-use crate::error::{api_error::ApiError, Error};
+use crate::error::{Error, api_error::ApiError};
 
 #[derive(Debug)]
 pub struct GetBlockClient {
@@ -22,16 +22,16 @@ impl GetBlockClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let block = serde_json::from_str::<crate::block::BlockResponse>(&body)?;
+        let block = serde_json::from_slice::<crate::block::BlockResponse>(&body)?;
 
         Ok(block)
     }

--- a/src/client/block/get_block_children.rs
+++ b/src/client/block/get_block_children.rs
@@ -1,4 +1,4 @@
-use crate::error::{api_error::ApiError, Error};
+use crate::error::{Error, api_error::ApiError};
 
 #[derive(Debug)]
 pub struct GetBlockChildrenClient {
@@ -21,11 +21,9 @@ impl GetBlockChildrenClient {
 
         let mut page_size_remain = self.page_size;
 
-        let block_id = &self
-            .block_id
-            .ok_or(Error::RequestParameter(
-                "`block_id` has not been set.".to_string(),
-            ))?;
+        let block_id = &self.block_id.ok_or(Error::RequestParameter(
+            "`block_id` has not been set.".to_string(),
+        ))?;
 
         let mut start_cursor = self.start_cursor;
 
@@ -52,16 +50,16 @@ impl GetBlockChildrenClient {
             let response = request.send().await?;
 
             if !response.status().is_success() {
-                let error_body = response.text().await?;
+                let error_body = response.bytes().await?;
 
-                let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+                let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
                 return Err(Error::Api(Box::new(error_json)));
             }
 
-            let body = response.text().await?;
+            let body = response.bytes().await?;
 
-            let block_list_response = serde_json::from_str::<
+            let block_list_response = serde_json::from_slice::<
                 crate::list_response::ListResponse<crate::block::BlockResponse>,
             >(&body)?;
 

--- a/src/client/block/update_block.rs
+++ b/src/client/block/update_block.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::error::{api_error::ApiError, Error};
+use crate::error::{Error, api_error::ApiError};
 
 #[derive(Debug)]
 pub struct UpdateBlockClient {
@@ -54,16 +54,16 @@ impl UpdateBlockClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let block = serde_json::from_str::<crate::block::BlockResponse>(&body)?;
+        let block = serde_json::from_slice::<crate::block::BlockResponse>(&body)?;
 
         Ok(block)
     }

--- a/src/client/database/create_database.rs
+++ b/src/client/database/create_database.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::{api_error::ApiError, Error},
     RichText,
+    error::{Error, api_error::ApiError},
 };
 
 #[derive(Debug, Default)]
@@ -76,17 +76,17 @@ impl CreateDatabaseClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
         let database: crate::database::DatabaseResponse =
-            serde_json::from_str::<crate::database::DatabaseResponse>(&body)?;
+            serde_json::from_slice::<crate::database::DatabaseResponse>(&body)?;
 
         Ok(database)
     }

--- a/src/client/database/query_database.rs
+++ b/src/client/database/query_database.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::{api_error::ApiError, Error},
+    error::{Error, api_error::ApiError},
     filter::Filter,
     list_response::ListResponse,
     page::page_response::PageResponse,
@@ -58,16 +58,17 @@ impl QueryDatabaseClient {
                         let response = request.send().await?;
 
                         if !response.status().is_success() {
-                            let error_body = response.text().await?;
+                            let error_body = response.bytes().await?;
 
-                            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+                            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
                             return Err(Error::Api(Box::new(error_json)));
                         }
 
-                        let body = response.text().await?;
+                        let body = response.bytes().await?;
 
-                        let mut pages = serde_json::from_str::<ListResponse<PageResponse>>(&body)?;
+                        let mut pages =
+                            serde_json::from_slice::<ListResponse<PageResponse>>(&body)?;
 
                         results.extend(pages.results);
 
@@ -92,16 +93,16 @@ impl QueryDatabaseClient {
                     let response = request.send().await?;
 
                     if !response.status().is_success() {
-                        let error_body = response.text().await?;
+                        let error_body = response.bytes().await?;
 
-                        let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+                        let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
                         return Err(Error::Api(Box::new(error_json)));
                     }
 
-                    let body = response.text().await?;
+                    let body = response.bytes().await?;
 
-                    let pages = serde_json::from_str::<ListResponse<PageResponse>>(&body)?;
+                    let pages = serde_json::from_slice::<ListResponse<PageResponse>>(&body)?;
 
                     Ok(pages)
                 }

--- a/src/client/database/retrieve_database.rs
+++ b/src/client/database/retrieve_database.rs
@@ -1,4 +1,4 @@
-use crate::error::{api_error::ApiError, Error};
+use crate::error::{Error, api_error::ApiError};
 
 #[derive(Debug, Default)]
 pub struct RetrieveDatabaseClient {
@@ -21,16 +21,16 @@ impl RetrieveDatabaseClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let database = serde_json::from_str::<crate::database::DatabaseResponse>(&body)?;
+        let database = serde_json::from_slice::<crate::database::DatabaseResponse>(&body)?;
 
         Ok(database)
     }

--- a/src/client/database/update_database.rs
+++ b/src/client/database/update_database.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::{api_error::ApiError, Error},
     RichText,
+    error::{Error, api_error::ApiError},
 };
 
 #[derive(Debug, Default)]
@@ -83,17 +83,17 @@ impl UpdateDatabaseClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
         let database: crate::database::DatabaseResponse =
-            serde_json::from_str::<crate::database::DatabaseResponse>(&body)?;
+            serde_json::from_slice::<crate::database::DatabaseResponse>(&body)?;
 
         Ok(database)
     }

--- a/src/client/page/create_page.rs
+++ b/src/client/page/create_page.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::{api_error::ApiError, Error},
+    error::{Error, api_error::ApiError},
     page::page_response::PageResponse,
 };
 
@@ -90,16 +90,16 @@ impl CreatePageClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let page: PageResponse = serde_json::from_str::<PageResponse>(&body)?;
+        let page: PageResponse = serde_json::from_slice::<PageResponse>(&body)?;
 
         Ok(page)
     }

--- a/src/client/page/get_page.rs
+++ b/src/client/page/get_page.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{api_error::ApiError, Error},
+    error::{Error, api_error::ApiError},
     page::page_response::PageResponse,
 };
 
@@ -22,16 +22,16 @@ impl GetPageClient {
                 let response = request.send().await?;
 
                 if !response.status().is_success() {
-                    let error_body = response.text().await?;
+                    let error_body = response.bytes().await?;
 
-                    let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+                    let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
                     return Err(Error::Api(Box::new(error_json)));
                 }
 
-                let body = response.text().await?;
+                let body = response.bytes().await?;
 
-                let page: PageResponse = serde_json::from_str::<PageResponse>(&body)?;
+                let page: PageResponse = serde_json::from_slice::<PageResponse>(&body)?;
 
                 Ok(page)
             }

--- a/src/client/page/get_page_property_item.rs
+++ b/src/client/page/get_page_property_item.rs
@@ -1,4 +1,4 @@
-use crate::error::{api_error::ApiError, Error};
+use crate::error::{Error, api_error::ApiError};
 
 #[derive(Debug)]
 pub struct GetPagePropertyItemClient {
@@ -31,16 +31,16 @@ impl GetPagePropertyItemClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let user = serde_json::from_str::<crate::page::properties::PageProperty>(&body)?;
+        let user = serde_json::from_slice::<crate::page::properties::PageProperty>(&body)?;
 
         Ok(user)
     }

--- a/src/client/page/update_page.rs
+++ b/src/client/page/update_page.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::{api_error::ApiError, Error},
+    error::{Error, api_error::ApiError},
     page::page_response::PageResponse,
 };
 
@@ -55,16 +55,16 @@ impl UpdatePageClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let page: PageResponse = serde_json::from_str::<PageResponse>(&body)?;
+        let page: PageResponse = serde_json::from_slice::<PageResponse>(&body)?;
 
         Ok(page)
     }

--- a/src/client/search/search_database.rs
+++ b/src/client/search/search_database.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::{api_error::ApiError, Error},
+    error::{Error, api_error::ApiError},
     prelude::ToJson,
 };
 
@@ -50,16 +50,16 @@ impl SearchDatabaseClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let pages = serde_json::from_str::<
+        let pages = serde_json::from_slice::<
             crate::list_response::ListResponse<crate::database::DatabaseResponse>,
         >(&body)?;
 

--- a/src/client/search/search_page.rs
+++ b/src/client/search/search_page.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::{api_error::ApiError, Error},
+    error::{Error, api_error::ApiError},
     prelude::ToJson,
 };
 
@@ -50,16 +50,16 @@ impl SearchPageClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
-            let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+            let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
             return Err(Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let pages = serde_json::from_str::<
+        let pages = serde_json::from_slice::<
             crate::list_response::ListResponse<crate::page::PageResponse>,
         >(&body)?;
 

--- a/src/client/user/get_self.rs
+++ b/src/client/user/get_self.rs
@@ -14,17 +14,17 @@ impl GetSelfClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            let error_body = response.text().await?;
+            let error_body = response.bytes().await?;
 
             let error_json =
-                serde_json::from_str::<crate::error::api_error::ApiError>(&error_body)?;
+                serde_json::from_slice::<crate::error::api_error::ApiError>(&error_body)?;
 
             return Err(crate::error::Error::Api(Box::new(error_json)));
         }
 
-        let body = response.text().await?;
+        let body = response.bytes().await?;
 
-        let user = serde_json::from_str::<crate::user::bot::Bot>(&body)?;
+        let user = serde_json::from_slice::<crate::user::bot::Bot>(&body)?;
 
         Ok(user)
     }

--- a/src/client/user/get_user.rs
+++ b/src/client/user/get_user.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{api_error::ApiError, Error},
+    error::{Error, api_error::ApiError},
     user::User,
 };
 
@@ -23,16 +23,16 @@ impl GetUserClient {
                 let response = request.send().await?;
 
                 if !response.status().is_success() {
-                    let error_body = response.text().await?;
+                    let error_body = response.bytes().await?;
 
-                    let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+                    let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
                     return Err(Error::Api(Box::new(error_json)));
                 }
 
-                let body = response.text().await?;
+                let body = response.bytes().await?;
 
-                let user = serde_json::from_str::<User>(&body)?;
+                let user = serde_json::from_slice::<User>(&body)?;
 
                 Ok(user)
             }

--- a/src/client/user/list_users.rs
+++ b/src/client/user/list_users.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 use crate::{
-    error::{api_error::ApiError, Error},
+    error::{Error, api_error::ApiError},
     list_response::ListResponse,
     user::User,
 };
@@ -55,16 +55,16 @@ impl ListUsersClient {
                 let response = request.send().await?;
 
                 if !response.status().is_success() {
-                    let error_body = response.text().await?;
+                    let error_body = response.bytes().await?;
 
-                    let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+                    let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
                     return Err(Error::Api(Box::new(error_json)));
                 }
 
-                let body = response.text().await?;
+                let body = response.bytes().await?;
 
-                let users_response = serde_json::from_str::<ListResponse<User>>(&body)?;
+                let users_response = serde_json::from_slice::<ListResponse<User>>(&body)?;
 
                 results.extend(users_response.results);
 
@@ -94,16 +94,16 @@ impl ListUsersClient {
             let response = request.send().await?;
 
             if !response.status().is_success() {
-                let error_body = response.text().await?;
+                let error_body = response.bytes().await?;
 
-                let error_json = serde_json::from_str::<ApiError>(&error_body)?;
+                let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
 
                 return Err(Error::Api(Box::new(error_json)));
             }
 
-            let body = response.text().await?;
+            let body = response.bytes().await?;
 
-            let users = serde_json::from_str::<ListResponse<User>>(&body)?;
+            let users = serde_json::from_slice::<ListResponse<User>>(&body)?;
 
             Ok(users)
         }


### PR DESCRIPTION
Replace text() with bytes() and from_str() with from_slice() for improved API response handling. This change enhances performance and efficiency in processing API responses.