### PR TITLE
Handle None values in Display implementations for SelectColor and PageSelectProperty

### DIFF
--- a/src/others/select.rs
+++ b/src/others/select.rs
@@ -97,7 +97,11 @@ impl std::str::FromStr for SelectColor {
 
 impl std::fmt::Display for SelectColor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_plain::to_string(self).unwrap())
+        write!(
+            f,
+            "{}",
+            serde_plain::to_string(self).unwrap_or("default".to_string())
+        )
     }
 }
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/select.rs
+++ b/src/page/properties/select.rs
@@ -54,7 +54,14 @@ where
 
 impl std::fmt::Display for PageSelectProperty {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.select.as_ref().unwrap())
+        write!(
+            f,
+            "{}",
+            self.select
+                .as_ref()
+                .map(|s| s.name.clone())
+                .unwrap_or("None".to_string())
+        )
     }
 }
 


### PR DESCRIPTION
Improve the Display trait implementations to handle potential None values gracefully, providing default representations instead.