### PR TITLE
chore: bump crate version to 1.0.0-alpha.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-alpha.32"
+version = "1.0.0-alpha.33"
 dependencies = [
  "chrono",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-alpha.32"
+version = "1.0.0-alpha.33"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"

--- a/src/others/select.rs
+++ b/src/others/select.rs
@@ -97,7 +97,11 @@ impl std::str::FromStr for SelectColor {
 
 impl std::fmt::Display for SelectColor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_plain::to_string(self).unwrap())
+        write!(
+            f,
+            "{}",
+            serde_plain::to_string(self).unwrap_or("default".to_string())
+        )
     }
 }
 // # --------------------------------------------------------------------------------

--- a/src/page/properties/select.rs
+++ b/src/page/properties/select.rs
@@ -54,7 +54,14 @@ where
 
 impl std::fmt::Display for PageSelectProperty {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.select.as_ref().unwrap())
+        write!(
+            f,
+            "{}",
+            self.select
+                .as_ref()
+                .map(|s| s.name.clone())
+                .unwrap_or("None".to_string())
+        )
     }
 }
 


### PR DESCRIPTION
## Bug Fixes

- refactored the main logic to use structured error handling instead of `unwrap()`
