### PR TITLE
feat: implement GetBlockChildrenAllClient for retrieving all block children

### DIFF
--- a/src/client/block/get_block_children_all.rs
+++ b/src/client/block/get_block_children_all.rs
@@ -1,0 +1,78 @@
+use crate::error::{Error, api_error::ApiError};
+
+#[derive(Debug)]
+pub struct GetBlockChildrenAllClient {
+    /// The reqwest http client
+    pub(crate) reqwest_client: reqwest::Client,
+
+    pub(crate) block_id: Option<String>,
+
+    pub(crate) start_cursor: Option<String>,
+}
+
+impl GetBlockChildrenAllClient {
+    // TODO: docs for send
+    pub async fn send(self) -> Result<Vec<crate::block::BlockResponse>, Error> {
+        let mut result_blocks: Vec<crate::block::BlockResponse> = vec![];
+
+        let block_id = &self.block_id.ok_or(Error::RequestParameter(
+            "`block_id` has not been set.".to_string(),
+        ))?;
+
+        let mut start_cursor = self.start_cursor;
+
+        loop {
+            let url = format!("https://api.notion.com/v1/blocks/{}/children", block_id);
+
+            let mut query_params: Vec<(String, String)> = vec![];
+
+            if let Some(ref cursor) = start_cursor {
+                query_params.push(("start_cursor".to_string(), cursor.to_string()))
+            }
+
+            let request = self.reqwest_client.get(url).query(&query_params);
+
+            let response = request.send().await?;
+
+            if !response.status().is_success() {
+                let error_body = response.bytes().await?;
+
+                let error_json = serde_json::from_slice::<ApiError>(&error_body)?;
+
+                return Err(Error::Api(Box::new(error_json)));
+            }
+
+            let body = response.bytes().await?;
+
+            let block_list_response = serde_json::from_slice::<
+                crate::list_response::ListResponse<crate::block::BlockResponse>,
+            >(&body)?;
+
+            result_blocks.extend(block_list_response.results);
+
+            start_cursor = block_list_response.next_cursor;
+
+            if start_cursor.is_none() {
+                return Ok(result_blocks);
+            }
+        }
+    }
+
+    // TODO: docs for block_id
+    pub fn block_id<T>(mut self, page_id: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        self.block_id = Some(page_id.as_ref().to_string());
+        self
+    }
+
+    // TODO: docs for start_cursor
+    pub fn start_cursor<T>(mut self, start_cursor: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        self.start_cursor = Some(start_cursor.as_ref().to_string());
+        self
+    }
+}

--- a/src/client/block/mod.rs
+++ b/src/client/block/mod.rs
@@ -2,4 +2,5 @@ pub mod append_block_children;
 pub mod delete_block;
 pub mod get_block;
 pub mod get_block_children;
+pub mod get_block_children_all;
 pub mod update_block;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -221,6 +221,17 @@ impl Client {
     }
 
     // TODO: docs
+    pub fn get_block_children_all(
+        &self,
+    ) -> crate::client::block::get_block_children_all::GetBlockChildrenAllClient {
+        crate::client::block::get_block_children_all::GetBlockChildrenAllClient {
+            reqwest_client: self.reqwest_client.clone(),
+            block_id: None,
+            start_cursor: None,
+        }
+    }
+
+    // TODO: docs
     pub fn delete_block(&self) -> crate::client::block::delete_block::DeleteBlockClient {
         crate::client::block::delete_block::DeleteBlockClient {
             reqwest_client: self.reqwest_client.clone(),


### PR DESCRIPTION
## Overview

- create a function that fetches all blocks without pagination.

## Related Issues

N/A

## Changes

- create `get_block_children_all()`

## Checklist

- [x] The target branch for this PR is either `develop` or `release/*`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] Documentation has been updated if necessary.

## Additional Notes

N/A
