### PR TITLE
Fix/add-table-of-contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules/
 # Vitepress
 **/.vitepress/cache/
 **/.vitepress/dist/
+
+.pnpm-store/

--- a/notionrs/examples/block_get_block_children.rs
+++ b/notionrs/examples/block_get_block_children.rs
@@ -58,6 +58,9 @@ async fn main() -> Result<(), Error> {
             Block::Pdf { pdf: _ } => todo!(),
             Block::Quote { quote: _ } => todo!(),
             Block::SyncedBlock { synced_block: _ } => todo!(),
+            Block::TableOfContents {
+                table_of_contents: _,
+            } => todo!(),
             Block::Table { table: _ } => todo!(),
             Block::TableRow { table_row: _ } => todo!(),
             Block::Template { template: _ } => todo!(),

--- a/notionrs/src/object/block/mod.rs
+++ b/notionrs/src/object/block/mod.rs
@@ -17,6 +17,7 @@ pub use self::paragraph::ParagraphBlock;
 pub use self::quote::QuoteBlock;
 pub use self::synced_block::SyncedBlock;
 pub use self::table::TableBlock;
+pub use self::table_of_contents::TableOfContentsBlock;
 pub use self::table_row::TableRowBlock;
 pub use self::template::TemplateBlock;
 pub use self::to_do::ToDoBlock;
@@ -39,6 +40,7 @@ pub mod paragraph;
 pub mod quote;
 pub mod synced_block;
 pub mod table;
+pub mod table_of_contents;
 pub mod table_row;
 pub mod template;
 pub mod to_do;
@@ -184,6 +186,9 @@ pub enum Block {
     SyncedBlock {
         synced_block: synced_block::SyncedBlock,
     },
+    TableOfContents {
+        table_of_contents: table_of_contents::TableOfContentsBlock,
+    },
     Table {
         table: table::TableBlock,
     },
@@ -232,6 +237,7 @@ impl std::fmt::Display for Block {
             Block::Pdf { pdf } => write!(f, "{}", pdf),
             Block::Quote { quote } => write!(f, "{}", quote),
             Block::SyncedBlock { synced_block } => write!(f, "{}", synced_block),
+            Block::TableOfContents { table_of_contents } => write!(f, "{}", table_of_contents),
             Block::Table { table } => write!(f, "{}", table),
             Block::TableRow { table_row } => write!(f, "{}", table_row),
             Block::Template { template } => write!(f, "{}", template),

--- a/notionrs/src/object/block/table_of_contents.rs
+++ b/notionrs/src/object/block/table_of_contents.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+/// <https://developers.notion.com/reference/block#table-of-contents>
+///
+/// Table of contents block objects contain the following information within the table_of_contents property:
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Copy, notionrs_macro::Setter)]
+pub struct TableOfContentsBlock {
+    /// The color of the block. Possible values are:
+    pub color: crate::object::color::Color,
+}
+
+impl std::fmt::Display for TableOfContentsBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.color)
+    }
+}
+
+// # --------------------------------------------------------------------------------
+//
+// unit test
+//
+// # --------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod unit_tests {
+
+    use super::TableOfContentsBlock;
+
+    #[test]
+    fn deserialize_block_table() {
+        let json_data = r#"
+        {
+            "color": "red"
+        }
+        "#;
+
+        let table = serde_json::from_str::<TableOfContentsBlock>(json_data).unwrap();
+
+        assert_eq!(table.color, crate::object::color::Color::Red);
+    }
+}


### PR DESCRIPTION
## Overview

- Add support for [table-of-contents](https://developers.notion.com/reference/block#table-of-contents)

## Related Issues

- Fixes https：#198

## Changes

- Create `table_of_contents` module and `TableOfContents` struct.

## Checklist

- [ ] The target branch for this PR is either `develop` or `release/*`.
- [ ] Unit tests have been added.
- [ ] All unit tests pass.
- [ ] Documentation has been updated if necessary.

## Additional Notes

- N/A
