### PR TITLE
Bump/1.0.0-alpha.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-alpha.37"
+version = "1.0.0-alpha.38"
 dependencies = [
  "chrono",
  "dotenvy",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-alpha.37"
+version = "1.0.0-alpha.38"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"


### PR DESCRIPTION
## Bug Fixes

- Add support for `TableOfContents` blocks.

## Dependency Updates

- Bump `reqwest` from 0.12.12 to 0.12.14.