### PR TITLE
Update workspace name in GitHub provider configuration

### DIFF
--- a/terraform/github/provider.tf
+++ b/terraform/github/provider.tf
@@ -12,7 +12,7 @@ terraform {
 
     workspaces {
       project = "notionrs"
-      name    = "shared"
+      name    = "notionrs"
     }
   }
 }


### PR DESCRIPTION
Change the workspace name from "shared" to "notionrs" in the GitHub provider configuration.