### PR TITLE
chore: bump crate version to v1.0.0-alpha.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-alpha.40"
+version = "1.0.0-alpha.41"
 dependencies = [
  "dotenvy",
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,21 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,21 +140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +162,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -488,29 +468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,7 +715,6 @@ dependencies = [
 name = "notionrs"
 version = "1.0.0-alpha.40"
 dependencies = [
- "chrono",
  "dotenvy",
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
@@ -767,6 +723,7 @@ dependencies = [
  "serde_plain",
  "serial_test",
  "thiserror",
+ "time",
  "tokio",
 ]
 
@@ -791,13 +748,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "object"
@@ -904,6 +858,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1414,6 +1374,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,15 +1706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -14,7 +14,6 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = { version = "0.4.41", features = ["serde"] }
 reqwest = { version = "0.12.15", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
@@ -22,6 +21,12 @@ serde_plain = "1.0.2"
 thiserror = "2.0.12"
 
 notionrs_macro = "1.0.0-alpha"
+time = { version = "0.3.41", features = [
+    "serde",
+    "parsing",
+    "formatting",
+    "macros",
+] }
 
 [dev-dependencies]
 tokio = { version = "1.44.2", features = ["full"] }

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-alpha.40"
+version = "1.0.0-alpha.41"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"

--- a/notionrs/src/lib.rs
+++ b/notionrs/src/lib.rs
@@ -5,3 +5,4 @@ pub mod client;
 pub mod error;
 pub mod r#macro;
 pub mod object;
+pub(crate) mod serde;

--- a/notionrs/src/object/block/mod.rs
+++ b/notionrs/src/object/block/mod.rs
@@ -85,13 +85,13 @@ pub struct BlockResponse {
 
     /// This value is provided in ISO 8601 format.
     /// To convert it back to the original string,
-    /// use the `.to_rfc3339()` method from `chrono`.
-    pub created_time: chrono::DateTime<chrono::FixedOffset>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_time: time::OffsetDateTime,
 
     /// This value is provided in ISO 8601 format.
     /// To convert it back to the original string,
-    /// use the `.to_rfc3339()` method from `chrono`.
-    pub last_edited_time: chrono::DateTime<chrono::FixedOffset>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub last_edited_time: time::OffsetDateTime,
 
     pub created_by: crate::object::user::User,
 
@@ -259,7 +259,6 @@ impl std::fmt::Display for Block {
 
 #[cfg(test)]
 mod unit_tests {
-    use chrono::TimeZone;
 
     use super::*;
 
@@ -325,11 +324,16 @@ mod unit_tests {
             _ => panic!(),
         }
 
-        let expected_created_time = chrono::Utc.with_ymd_and_hms(2024, 8, 17, 2, 50, 0).unwrap();
+        let expected_created_time = time::OffsetDateTime::new_utc(
+            time::Date::from_calendar_date(2024, time::Month::August, 17).unwrap(),
+            time::Time::from_hms(2, 50, 0).unwrap(),
+        );
         assert_eq!(block.created_time, expected_created_time);
 
-        let expected_last_edited_time =
-            chrono::Utc.with_ymd_and_hms(2024, 8, 17, 2, 50, 0).unwrap();
+        let expected_last_edited_time = time::OffsetDateTime::new_utc(
+            time::Date::from_calendar_date(2024, time::Month::August, 17).unwrap(),
+            time::Time::from_hms(2, 50, 0).unwrap(),
+        );
         assert_eq!(block.last_edited_time, expected_last_edited_time);
 
         assert_eq!(block.created_by.object, "user");

--- a/notionrs/src/object/date.rs
+++ b/notionrs/src/object/date.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents either a `Date` (`YYYY-MM-DD`) or a full `OffsetDateTime` (`RFC 3339`) value.
+///
+/// This enum is useful when the input format can vary between:
+/// - A date-only string, like `"2024-05-01"`
+/// - A full datetime string with offset, like `"2024-05-01T00:00:00Z"`
+///
+/// When deserializing, the format determines which variant is used:
+/// - `"YYYY-MM-DD"` → [`DateOrDateTime::Date`]
+/// - RFC 3339 datetime → [`DateOrDateTime::DateTime`]
+///
+/// ### Examples
+/// ```json
+/// "2024-05-01"                  // => Date(...)
+/// "2024-05-01T00:00:00+00:00"   // => DateTime(...)
+/// ```
+///
+/// This enum uses custom (de)serializers to support both formats.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum DateOrDateTime {
+    /// A date-only value (e.g. `"2024-05-01"`).
+    #[serde(with = "crate::serde::date")]
+    Date(time::Date),
+
+    /// A full date-time with offset (RFC 3339 format).
+    #[serde(with = "time::serde::rfc3339")]
+    DateTime(time::OffsetDateTime),
+}
+
+impl std::fmt::Display for DateOrDateTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let date = match self {
+            DateOrDateTime::Date(date) => date.to_string(),
+            DateOrDateTime::DateTime(offset_date_time) => offset_date_time.to_string(),
+        };
+
+        write!(f, "{}", date)
+    }
+}
+
+impl Default for DateOrDateTime {
+    fn default() -> Self {
+        Self::DateTime(time::OffsetDateTime::now_utc())
+    }
+}

--- a/notionrs/src/object/mod.rs
+++ b/notionrs/src/object/mod.rs
@@ -1,6 +1,7 @@
 pub mod block;
 pub mod color;
 pub mod database;
+pub mod date;
 pub mod emoji;
 pub mod file;
 pub mod icon;

--- a/notionrs/src/object/page/created_time.rs
+++ b/notionrs/src/object/page/created_time.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 ///   }
 /// }
 /// ```
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default, notionrs_macro::Setter)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, notionrs_macro::Setter)]
 pub struct PageCreatedTimeProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
@@ -30,13 +30,29 @@ pub struct PageCreatedTimeProperty {
 
     /// The date and time that the page was created.
     /// The created_time value can’t be updated.
-    pub created_time: chrono::DateTime<chrono::FixedOffset>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_time: time::OffsetDateTime,
+}
+
+impl Default for PageCreatedTimeProperty {
+    fn default() -> Self {
+        self::PageCreatedTimeProperty {
+            id: None,
+            created_time: time::OffsetDateTime::now_utc(),
+        }
+    }
 }
 
 impl std::fmt::Display for PageCreatedTimeProperty {
     /// display the created time in RFC3339 format
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.created_time.to_rfc3339())
+        write!(
+            f,
+            "{}",
+            self.created_time
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap()
+        )
     }
 }
 
@@ -48,7 +64,6 @@ impl std::fmt::Display for PageCreatedTimeProperty {
 
 #[cfg(test)]
 mod unit_tests {
-    use chrono::TimeZone;
 
     use super::*;
 
@@ -73,7 +88,10 @@ mod unit_tests {
 
         assert_eq!(created_time.id, Some("sv%3Fi".to_string()));
 
-        let expected_created_time = chrono::Utc.with_ymd_and_hms(2024, 4, 3, 10, 55, 0).unwrap();
+        let expected_created_time = time::OffsetDateTime::new_utc(
+            time::Date::from_calendar_date(2024, time::Month::April, 3).unwrap(),
+            time::Time::from_hms(10, 55, 0).unwrap(),
+        );
         assert_eq!(created_time.created_time, expected_created_time);
     }
 }

--- a/notionrs/src/object/page/created_time.rs
+++ b/notionrs/src/object/page/created_time.rs
@@ -36,7 +36,7 @@ pub struct PageCreatedTimeProperty {
 
 impl Default for PageCreatedTimeProperty {
     fn default() -> Self {
-        self::PageCreatedTimeProperty {
+        Self {
             id: None,
             created_time: time::OffsetDateTime::now_utc(),
         }

--- a/notionrs/src/object/page/formula.rs
+++ b/notionrs/src/object/page/formula.rs
@@ -87,7 +87,7 @@ pub struct FormulaBoolean {
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub struct FormulaDate {
     /// Calculated value of the database property
-    pub date: Option<chrono::DateTime<chrono::FixedOffset>>,
+    pub date: Option<crate::object::date::DateOrDateTime>,
 }
 
 /// ```json

--- a/notionrs/src/object/page/last_edited_time.rs
+++ b/notionrs/src/object/page/last_edited_time.rs
@@ -28,13 +28,20 @@ pub struct PageLastEditedTimeProperty {
     pub id: Option<String>,
 
     /// The date and time that the page was last edited.
-    pub last_edited_time: chrono::DateTime<chrono::FixedOffset>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub last_edited_time: time::OffsetDateTime,
 }
 
 impl std::fmt::Display for PageLastEditedTimeProperty {
     /// Display
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.last_edited_time.to_rfc3339())
+        write!(
+            f,
+            "{}",
+            self.last_edited_time
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or("[Invalid Format]".to_owned())
+        )
     }
 }
 
@@ -46,8 +53,6 @@ impl std::fmt::Display for PageLastEditedTimeProperty {
 
 #[cfg(test)]
 mod unit_tests {
-
-    use chrono::TimeZone;
 
     use super::*;
 
@@ -71,8 +76,11 @@ mod unit_tests {
         let last_edited_time = last_edited_time_map.get("Last edited time").unwrap();
 
         assert_eq!(last_edited_time.id, Some("sv%3Fi".to_string()));
-        let expected_last_edited_time =
-            chrono::Utc.with_ymd_and_hms(2024, 4, 3, 10, 55, 0).unwrap();
+
+        let expected_last_edited_time = time::OffsetDateTime::new_utc(
+            time::Date::from_calendar_date(2024, time::Month::April, 3).unwrap(),
+            time::Time::from_hms(10, 55, 0).unwrap(),
+        );
         assert_eq!(last_edited_time.last_edited_time, expected_last_edited_time);
     }
 }

--- a/notionrs/src/object/page/last_edited_time.rs
+++ b/notionrs/src/object/page/last_edited_time.rs
@@ -39,7 +39,8 @@ impl std::fmt::Display for PageLastEditedTimeProperty {
             f,
             "{}",
             self.last_edited_time
-                .format(&time::format_description::well_known::Rfc3339)?
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or("[Invalid Format]".to_owned())
         )
     }
 }

--- a/notionrs/src/object/page/last_edited_time.rs
+++ b/notionrs/src/object/page/last_edited_time.rs
@@ -39,8 +39,7 @@ impl std::fmt::Display for PageLastEditedTimeProperty {
             f,
             "{}",
             self.last_edited_time
-                .format(&time::format_description::well_known::Rfc3339)
-                .unwrap_or("[Invalid Format]".to_owned())
+                .format(&time::format_description::well_known::Rfc3339)?
         )
     }
 }

--- a/notionrs/src/object/page/mod.rs
+++ b/notionrs/src/object/page/mod.rs
@@ -103,8 +103,10 @@ impl std::fmt::Display for PageProperty {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageResponse {
     pub id: String,
-    pub created_time: chrono::DateTime<chrono::FixedOffset>,
-    pub last_edited_time: chrono::DateTime<chrono::FixedOffset>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_time: time::OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub last_edited_time: time::OffsetDateTime,
     pub created_by: User,
     pub last_edited_by: User,
     pub cover: Option<File>,

--- a/notionrs/src/object/page/verification.rs
+++ b/notionrs/src/object/page/verification.rs
@@ -1,5 +1,4 @@
-use chrono::TimeZone;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// <https://developers.notion.com/reference/page-property-values#verification>
 ///
@@ -45,44 +44,15 @@ pub enum PageVerificationState {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default, notionrs_macro::Setter)]
 pub struct PageVerificationDate {
     /// A date, with an optional time.
-    #[serde(deserialize_with = "deserialize_date_or_datetime")]
-    pub start: Option<chrono::DateTime<chrono::FixedOffset>>,
+    pub start: Option<crate::object::date::DateOrDateTime>,
 
     /// A string representing the end of a date range.
     /// If the value is null, then the date value is not a range.
-    #[serde(deserialize_with = "deserialize_date_or_datetime")]
-    pub end: Option<chrono::DateTime<chrono::FixedOffset>>,
+    pub end: Option<crate::object::date::DateOrDateTime>,
 
     /// Always `null`. The time zone is already included in the formats of start and end times.
     #[serde(skip_deserializing)]
     pub time_zone: Option<String>,
-}
-
-fn deserialize_date_or_datetime<'de, D>(
-    deserializer: D,
-) -> Result<Option<chrono::DateTime<chrono::FixedOffset>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let date_str = Option::<String>::deserialize(deserializer)?;
-
-    if let Some(date_str) = date_str {
-        if let Ok(date) = chrono::NaiveDate::parse_from_str(&date_str, "%Y-%m-%d") {
-            return Ok(Some(
-                chrono::FixedOffset::east_opt(0).unwrap().from_utc_datetime(
-                    &date
-                        .and_hms_opt(0, 0, 0)
-                        .ok_or_else(|| serde::de::Error::custom("Invalid time"))?,
-                ),
-            ));
-        }
-        if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(&date_str) {
-            return Ok(Some(datetime));
-        }
-        return Err(serde::de::Error::custom("Invalid date or datetime format"));
-    }
-
-    Ok(None)
 }
 
 impl PageVerificationProperty {

--- a/notionrs/src/serde/date.rs
+++ b/notionrs/src/serde/date.rs
@@ -1,0 +1,24 @@
+//! Defines custom serializers and deserializers for `time::Date`
+//! using `YYYY-MM-DD` format.
+
+use serde::{Deserialize, Deserializer, Serializer, de::Error};
+
+/// Serializes a `Date` into a `YYYY-MM-DD` string.
+pub fn serialize<S>(value: &time::Date, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let format = time::macros::format_description!("[year]-[month]-[day]");
+    let s = value.format(&format).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&s)
+}
+
+/// Deserializes a `YYYY-MM-DD` string into a `Date`.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<time::Date, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let format = time::macros::format_description!("[year]-[month]-[day]");
+    time::Date::parse(&s, &format).map_err(D::Error::custom)
+}

--- a/notionrs/src/serde/mod.rs
+++ b/notionrs/src/serde/mod.rs
@@ -1,0 +1,1 @@
+pub mod date;

--- a/notionrs/tests/page/crud_page_with_database.rs
+++ b/notionrs/tests/page/crud_page_with_database.rs
@@ -167,7 +167,13 @@ mod integration_tests {
             "Date".to_string(),
             notionrs::object::page::PageProperty::Date(
                 notionrs::object::page::PageDateProperty::from(
-                    chrono::DateTime::parse_from_rfc3339("2024-10-26T09:03:00.000Z").unwrap(),
+                    notionrs::object::date::DateOrDateTime::DateTime(
+                        time::OffsetDateTime::parse(
+                            "2024-10-26T09:03:00.000Z",
+                            &time::format_description::well_known::Rfc3339,
+                        )
+                        .unwrap(),
+                    ),
                 ),
             ),
         );


### PR DESCRIPTION
## Overview

- Replace the `chrono` crate with the `time` crate.

## Related Issues

N/A

## Changes

- Rewrote serialization and deserialization logic to use the `time` crate instead of `chrono`.

## Checklist

- [x] The target branch for this PR is either `develop` or `release/*`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] Documentation has been updated if necessary.

## Additional Notes

N/A
