### PR TITLE
chore: bump notionrs version to 1.0.0-alpha.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-alpha.41"
+version = "1.0.0-alpha.42"
 dependencies = [
  "dotenvy",
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-alpha.41"
+version = "1.0.0-alpha.42"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"


### PR DESCRIPTION
## Features

- Added support for creating comments (`create_comment`).
- Added support for retrieving comments (`retrieve_comments`).
