### PR TITLE
fix: update terraform directory path in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
       - "46ki75"
 
   - package-ecosystem: "terraform"
-    directory: "/terraform"
+    directory: "/terraform/github"
     schedule:
       interval: "daily"
     target-branch: "main"


### PR DESCRIPTION
## Overview

- Fixed the dependabot configuration.

## Related Issues

N/A

## Changes

- Corrected the target directory path to `/terraform/github` in the dependabot configuration.

## Checklist

- [x] The target branch for this PR is either `develop` or `release/*`.
- [~] Unit tests have been added.
- [x] All unit tests pass.
- [~] Documentation has been updated if necessary.

## Additional Notes

N/A
