### PR TITLE
Re-exported modules in the prelude module

### DIFF
--- a/notionrs/examples/block_append_block_children.rs
+++ b/notionrs/examples/block_append_block_children.rs
@@ -1,4 +1,5 @@
-use notionrs::{client::Client, error::Error, object::rich_text::RichText};
+use notionrs::prelude::*;
+use notionrs::{Client, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -6,8 +7,8 @@ async fn main() -> Result<(), Error> {
 
     let rich_text = RichText::from("rich text");
 
-    let block = notionrs::object::block::Block::Paragraph {
-        paragraph: notionrs::object::block::ParagraphBlock::default()
+    let block = Block::Paragraph {
+        paragraph: ParagraphBlock::default()
             .rich_text(vec![rich_text.clone()])
             .blue_background(),
     };

--- a/notionrs/examples/block_delete_block.rs
+++ b/notionrs/examples/block_delete_block.rs
@@ -1,4 +1,4 @@
-use notionrs::{client::Client, error::Error};
+use notionrs::{Client, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/notionrs/examples/block_get_block_children.rs
+++ b/notionrs/examples/block_get_block_children.rs
@@ -1,14 +1,11 @@
-use notionrs::{
-    client::Client,
-    error::Error,
-    object::block::{Block, BlockResponse},
-};
+use notionrs::prelude::*;
+use notionrs::{Client, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     let client = Client::new().secret("API_KEY");
 
-    let request: notionrs::client::block::get_block_children::GetBlockChildrenClient = client
+    let request = client
         .get_block_children()
         .block_id("BLOCK_ID")
         .page_size(100);

--- a/notionrs/examples/block_update_block.rs
+++ b/notionrs/examples/block_update_block.rs
@@ -1,4 +1,5 @@
-use notionrs::{client::Client, error::Error, object::rich_text::RichText};
+use notionrs::prelude::*;
+use notionrs::{Client, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -6,8 +7,8 @@ async fn main() -> Result<(), Error> {
 
     let rich_text = RichText::from("rich text");
 
-    let block = notionrs::object::block::Block::Paragraph {
-        paragraph: notionrs::object::block::ParagraphBlock::default()
+    let block = Block::Paragraph {
+        paragraph: ParagraphBlock::default()
             .rich_text(vec![rich_text.clone()])
             .blue_background(),
     };

--- a/notionrs/examples/database_create_database.rs
+++ b/notionrs/examples/database_create_database.rs
@@ -1,13 +1,7 @@
 use std::collections::HashMap;
 
-use notionrs::{
-    client::Client,
-    error::Error,
-    object::{
-        database::{DatabaseEmailProperty, DatabaseProperty},
-        rich_text::RichText,
-    },
-};
+use notionrs::prelude::*;
+use notionrs::{Client, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/notionrs/examples/database_update_database.rs
+++ b/notionrs/examples/database_update_database.rs
@@ -1,18 +1,5 @@
-use notionrs::{
-    client::Client,
-    error::Error,
-    object::{
-        database::{
-            DatabaseMultiSelectProperty, DatabaseProperty, DatabaseRichTextProperty,
-            DatabaseUrlProperty,
-        },
-        emoji::Emoji,
-        file::{ExternalFile, File},
-        icon::Icon,
-        rich_text::RichText,
-        select::{Select, SelectColor},
-    },
-};
+use notionrs::prelude::*;
+use notionrs::{Client, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/notionrs/examples/page_create_page.rs
+++ b/notionrs/examples/page_create_page.rs
@@ -1,11 +1,5 @@
-use notionrs::{
-    client::Client,
-    error::Error,
-    object::{
-        page::{PageMultiSelectProperty, PageProperty, PageTitleProperty},
-        select::{Select, SelectColor},
-    },
-};
+use notionrs::prelude::*;
+use notionrs::{Client, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/notionrs/examples/page_update_page.rs
+++ b/notionrs/examples/page_update_page.rs
@@ -1,8 +1,5 @@
-use notionrs::{
-    client::Client,
-    error::Error,
-    object::page::{PageProperty, PageTitleProperty},
-};
+use notionrs::prelude::*;
+use notionrs::{Client, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/notionrs/src/lib.rs
+++ b/notionrs/src/lib.rs
@@ -5,4 +5,8 @@ pub mod client;
 pub mod error;
 pub mod r#macro;
 pub mod object;
+pub mod prelude;
 pub(crate) mod serde;
+
+pub use crate::client::Client;
+pub use crate::error::Error;

--- a/notionrs/src/object/block/mod.rs
+++ b/notionrs/src/object/block/mod.rs
@@ -1,28 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-pub use self::bookmark::BookmarkBlock;
-pub use self::bulleted_list_item::BulletedListItemBlock;
-pub use self::callout::CalloutBlock;
-pub use self::child_database::ChildDatabaseBlock;
-pub use self::child_page::ChildPageBlock;
-pub use self::code::CodeBlock;
-pub use self::column::ColumnBlock;
-pub use self::column_list::ColumnListBlock;
-pub use self::embed::EmbedBlock;
-pub use self::equation::EquationBlock;
-pub use self::heading::HeadingBlock;
-pub use self::link_preview::LinkPreviewBlock;
-pub use self::numbered_list_item::NumberedListItemBlock;
-pub use self::paragraph::ParagraphBlock;
-pub use self::quote::QuoteBlock;
-pub use self::synced_block::SyncedBlock;
-pub use self::table::TableBlock;
-pub use self::table_of_contents::TableOfContentsBlock;
-pub use self::table_row::TableRowBlock;
-pub use self::template::TemplateBlock;
-pub use self::to_do::ToDoBlock;
-pub use self::toggle::ToggleBlock;
-
 pub mod bookmark;
 pub mod bulleted_list_item;
 pub mod callout;

--- a/notionrs/src/object/database/mod.rs
+++ b/notionrs/src/object/database/mod.rs
@@ -24,20 +24,6 @@ pub mod unique_id;
 pub mod url;
 pub mod verification;
 
-pub use {
-    button::DatabaseButtonProperty, checkbox::DatabaseCheckboxProperty,
-    created_by::DatabaseCreatedByProperty, created_time::DatabaseCreatedTimeProperty,
-    date::DatabaseDateProperty, email::DatabaseEmailProperty, files::DatabaseFilesProperty,
-    formula::DatabaseFormulaProperty, last_edited_by::DatabaseLastEditedByProperty,
-    last_edited_time::DatabaseLastEditedTimeProperty, multi_select::DatabaseMultiSelectProperty,
-    number::DatabaseNumberProperty, people::DatabasePeopleProperty,
-    phone_number::DatabasePhoneNumberProperty, relation::DatabaseRelationProperty,
-    rich_text::DatabaseRichTextProperty, rollup::*, select::DatabaseSelectProperty,
-    status::DatabaseStatusProperty, title::DatabaseTitleProperty,
-    unique_id::DatabaseUniqueIdProperty, url::DatabaseUrlProperty,
-    verification::DatabaseVerificationProperty,
-};
-
 #[derive(Debug, Deserialize, Serialize, Clone, notionrs_macro::Setter)]
 pub struct DatabaseResponse {
     pub id: String,

--- a/notionrs/src/object/database/status.rs
+++ b/notionrs/src/object/database/status.rs
@@ -15,11 +15,11 @@ pub struct DatabaseStatusProperty {
     #[serde(skip_serializing)]
     pub description: Option<String>,
 
-    pub status: DatabaseSelectOptionProperty,
+    pub status: DatabaseStatusOptionProperty,
 }
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq, notionrs_macro::Setter)]
-pub struct DatabaseSelectOptionProperty {
+pub struct DatabaseStatusOptionProperty {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     options: Vec<crate::object::select::Select>,
 

--- a/notionrs/src/object/mod.rs
+++ b/notionrs/src/object/mod.rs
@@ -1,16 +1,17 @@
 pub mod block;
+pub mod database;
+pub mod page;
+pub mod request;
+pub mod rich_text;
+
 pub mod color;
 pub mod comment;
-pub mod database;
 pub mod date;
 pub mod emoji;
 pub mod file;
 pub mod icon;
 pub mod language;
-pub mod page;
 pub mod parent;
-pub mod request;
 pub mod response;
-pub mod rich_text;
 pub mod select;
 pub mod user;

--- a/notionrs/src/object/page/mod.rs
+++ b/notionrs/src/object/page/mod.rs
@@ -29,18 +29,6 @@ pub mod unique_id;
 pub mod url;
 pub mod verification;
 
-pub use {
-    button::PageButtonProperty, checkbox::PageCheckboxProperty, created_by::PageCreatedByProperty,
-    created_time::PageCreatedTimeProperty, date::PageDateProperty, email::PageEmailProperty,
-    files::PageFilesProperty, formula::PageFormulaProperty,
-    last_edited_by::PageLastEditedByProperty, last_edited_time::PageLastEditedTimeProperty,
-    multi_select::PageMultiSelectProperty, number::PageNumberProperty, people::PagePeopleProperty,
-    phone_number::PagePhoneNumberProperty, relation::PageRelationProperty,
-    rich_text::PageRichTextProperty, rollup::PageRollupProperty, select::PageSelectProperty,
-    status::PageStatusProperty, title::PageTitleProperty, unique_id::PageUniqueIdProperty,
-    url::PageUrlProperty, verification::PageVerificationProperty,
-};
-
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PageProperty {

--- a/notionrs/src/prelude.rs
+++ b/notionrs/src/prelude.rs
@@ -1,24 +1,24 @@
 pub use crate::object::{
     block::{
-        bookmark::*, bulleted_list_item::*, callout::*, child_database::*, child_page::*, code::*,
-        column::*, column_list::*, embed::*, equation::*, heading::*, link_preview::*,
-        numbered_list_item::*, paragraph::*, quote::*, synced_block::*, table::*,
+        Block, BlockResponse, bookmark::*, bulleted_list_item::*, callout::*, child_database::*,
+        child_page::*, code::*, column::*, column_list::*, embed::*, equation::*, heading::*,
+        link_preview::*, numbered_list_item::*, paragraph::*, quote::*, synced_block::*, table::*,
         table_of_contents::*, table_row::*, template::*, to_do::*, toggle::*,
     },
     database::{
-        button::*, checkbox::*, created_by::*, created_time::*, date::*, email::*, files::*,
-        formula::*, last_edited_by::*, last_edited_time::*, multi_select::*, number::*, people::*,
-        phone_number::*, relation::*, rich_text::*, rollup::*, select::*, status::*, title::*,
-        unique_id::*, url::*, verification::*,
+        DatabaseProperty, DatabaseResponse, button::*, checkbox::*, created_by::*, created_time::*,
+        date::*, email::*, files::*, formula::*, last_edited_by::*, last_edited_time::*,
+        multi_select::*, number::*, people::*, phone_number::*, relation::*, rich_text::*,
+        rollup::*, select::*, status::*, title::*, unique_id::*, url::*, verification::*,
     },
     page::{
-        button::*, checkbox::*, created_by::*, created_time::*, date::*, email::*, files::*,
-        formula::*, last_edited_by::*, last_edited_time::*, multi_select::*, number::*, people::*,
-        phone_number::*, relation::*, rich_text::*, rollup::*, select::*, status::*, title::*,
-        unique_id::*, url::*, verification::*,
+        PageProperty, PageResponse, button::*, checkbox::*, created_by::*, created_time::*,
+        date::*, email::*, files::*, formula::*, last_edited_by::*, last_edited_time::*,
+        multi_select::*, number::*, people::*, phone_number::*, relation::*, rich_text::*,
+        rollup::*, select::*, status::*, title::*, unique_id::*, url::*, verification::*, *,
     },
     request::{filter::*, search::*, sort::*},
-    rich_text::{equation::*, mention::*, text::*},
+    rich_text::{RichText, RichTextAnnotations, equation::*, mention::*, text::*},
 };
 
 pub use crate::object::{

--- a/notionrs/src/prelude.rs
+++ b/notionrs/src/prelude.rs
@@ -1,0 +1,27 @@
+pub use crate::object::{
+    block::{
+        bookmark::*, bulleted_list_item::*, callout::*, child_database::*, child_page::*, code::*,
+        column::*, column_list::*, embed::*, equation::*, heading::*, link_preview::*,
+        numbered_list_item::*, paragraph::*, quote::*, synced_block::*, table::*,
+        table_of_contents::*, table_row::*, template::*, to_do::*, toggle::*,
+    },
+    database::{
+        button::*, checkbox::*, created_by::*, created_time::*, date::*, email::*, files::*,
+        formula::*, last_edited_by::*, last_edited_time::*, multi_select::*, number::*, people::*,
+        phone_number::*, relation::*, rich_text::*, rollup::*, select::*, status::*, title::*,
+        unique_id::*, url::*, verification::*,
+    },
+    page::{
+        button::*, checkbox::*, created_by::*, created_time::*, date::*, email::*, files::*,
+        formula::*, last_edited_by::*, last_edited_time::*, multi_select::*, number::*, people::*,
+        phone_number::*, relation::*, rich_text::*, rollup::*, select::*, status::*, title::*,
+        unique_id::*, url::*, verification::*,
+    },
+    request::{filter::*, search::*, sort::*},
+    rich_text::{equation::*, mention::*, text::*},
+};
+
+pub use crate::object::{
+    color::*, comment::*, date::*, emoji::*, file::*, icon::*, language::*, parent::*, response::*,
+    select::*, user::*,
+};

--- a/notionrs/tests/block/crud_audio_block.rs
+++ b/notionrs/tests/block/crud_audio_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_audio_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_audio_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,12 +18,10 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let block = notionrs::object::block::Block::Audio {
+        let block = Block::Audio {
             audio: notionrs::object::file::File::default()
                 .url("https://example.com/sample.wav")
-                .caption(vec![notionrs::object::rich_text::RichText::from(
-                    "my caption",
-                )]),
+                .caption(vec![RichText::from("my caption")]),
         };
 
         let request = client
@@ -50,9 +50,9 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Audio { audio } => {
+            Block::Audio { audio } => {
                 assert_eq!(audio.get_url(), "https://example.com/sample.wav");
-                notionrs::object::block::Block::Audio {
+                Block::Audio {
                     audio: audio.url("https://example.com/foobar.wav"),
                 }
             }

--- a/notionrs/tests/block/crud_bookmark_block.rs
+++ b/notionrs/tests/block/crud_bookmark_block.rs
@@ -1,14 +1,15 @@
 mod integration_tests {
+    use notionrs::prelude::*;
 
     #[tokio::test]
-    async fn crud_bookmark_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_bookmark_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,8 +17,8 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let block = notionrs::object::block::Block::Bookmark {
-            bookmark: notionrs::object::block::BookmarkBlock::default().url("https://example.com"),
+        let block = Block::Bookmark {
+            bookmark: BookmarkBlock::default().url("https://example.com"),
         };
 
         let request = client
@@ -46,9 +47,9 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Bookmark { bookmark } => {
+            Block::Bookmark { bookmark } => {
                 assert_eq!(bookmark.url, "https://example.com");
-                notionrs::object::block::Block::Bookmark {
+                Block::Bookmark {
                     bookmark: bookmark.url("https://example.com/index.html"),
                 }
             }

--- a/notionrs/tests/block/crud_breadcrumb_block.rs
+++ b/notionrs/tests/block/crud_breadcrumb_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_breadcrumb_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_breadcrumb_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,7 +18,7 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let block = notionrs::object::block::Block::Breadcrumb {
+        let block = Block::Breadcrumb {
             breadcrumb: std::collections::HashMap::new(),
         };
 

--- a/notionrs/tests/block/crud_bulleted_list_item_block.rs
+++ b/notionrs/tests/block/crud_bulleted_list_item_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_bulleted_list_item_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_bulleted_list_item_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,10 +18,10 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("list item");
+        let rich_text = RichText::from("list item");
 
-        let block = notionrs::object::block::Block::BulletedListItem {
-            bulleted_list_item: notionrs::object::block::BulletedListItemBlock::default()
+        let block = Block::BulletedListItem {
+            bulleted_list_item: BulletedListItemBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .blue_background(),
         };
@@ -50,13 +52,13 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::BulletedListItem { bulleted_list_item } => {
+            Block::BulletedListItem { bulleted_list_item } => {
                 assert_eq!(bulleted_list_item.rich_text, vec![rich_text]);
                 assert_eq!(
                     bulleted_list_item.color,
                     notionrs::object::color::Color::BlueBackground
                 );
-                notionrs::object::block::Block::BulletedListItem {
+                Block::BulletedListItem {
                     bulleted_list_item: bulleted_list_item.green_background(),
                 }
             }

--- a/notionrs/tests/block/crud_callout_block.rs
+++ b/notionrs/tests/block/crud_callout_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_callout_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_callout_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,10 +18,10 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("callout!");
+        let rich_text = RichText::from("callout!");
 
-        let block = notionrs::object::block::Block::Callout {
-            callout: notionrs::object::block::CalloutBlock::default()
+        let block = Block::Callout {
+            callout: CalloutBlock::default()
                 .blue_background()
                 .rich_text(vec![rich_text.clone()]),
         };
@@ -50,13 +52,13 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Callout { callout } => {
+            Block::Callout { callout } => {
                 assert_eq!(callout.rich_text, vec![rich_text]);
                 assert_eq!(
                     callout.color,
                     notionrs::object::color::Color::BlueBackground
                 );
-                notionrs::object::block::Block::Callout {
+                Block::Callout {
                     callout: callout.green_background(),
                 }
             }

--- a/notionrs/tests/block/crud_code_block.rs
+++ b/notionrs/tests/block/crud_code_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_code_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_code_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,12 +18,12 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("console.log(0)");
+        let rich_text = RichText::from("console.log(0)");
 
-        let caption = notionrs::object::rich_text::RichText::from("index.js");
+        let caption = RichText::from("index.js");
 
-        let block = notionrs::object::block::Block::Code {
-            code: notionrs::object::block::CodeBlock::default()
+        let block = Block::Code {
+            code: CodeBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .caption(vec![caption.clone()])
                 .lnaguage(notionrs::object::language::Language::Javascript),
@@ -53,19 +55,17 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Code { code } => {
+            Block::Code { code } => {
                 assert_eq!(code.rich_text, vec![rich_text]);
                 assert_eq!(code.caption, vec![caption]);
                 assert_eq!(
                     code.language,
                     notionrs::object::language::Language::Javascript
                 );
-                notionrs::object::block::Block::Code {
+                Block::Code {
                     code: code
                         .lnaguage(notionrs::object::language::Language::Typescript)
-                        .caption(vec![notionrs::object::rich_text::RichText::from(
-                            "index.ts",
-                        )]),
+                        .caption(vec![RichText::from("index.ts")]),
                 }
             }
             e => panic!("{:?}", e),

--- a/notionrs/tests/block/crud_column_list_block.rs
+++ b/notionrs/tests/block/crud_column_list_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_column_list_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_column_list_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,20 +18,18 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("child");
+        let rich_text = RichText::from("child");
 
-        let grandchildren = notionrs::object::block::Block::Paragraph {
-            paragraph: notionrs::object::block::ParagraphBlock::default()
-                .rich_text(vec![rich_text.clone()]),
+        let grandchildren = Block::Paragraph {
+            paragraph: ParagraphBlock::default().rich_text(vec![rich_text.clone()]),
         };
 
-        let child = notionrs::object::block::Block::Column {
-            column: notionrs::object::block::ColumnBlock::default().children(vec![grandchildren]),
+        let child = Block::Column {
+            column: ColumnBlock::default().children(vec![grandchildren]),
         };
 
-        let block = notionrs::object::block::Block::ColumnList {
-            column_list: notionrs::object::block::ColumnListBlock::default()
-                .children(vec![child.clone(), child.clone()]),
+        let block = Block::ColumnList {
+            column_list: ColumnListBlock::default().children(vec![child.clone(), child.clone()]),
         };
 
         let request = client

--- a/notionrs/tests/block/crud_embed_block.rs
+++ b/notionrs/tests/block/crud_embed_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_embed_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_embed_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,8 +18,8 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let block = notionrs::object::block::Block::Embed {
-            embed: notionrs::object::block::EmbedBlock::default().url("https://example.com"),
+        let block = Block::Embed {
+            embed: EmbedBlock::default().url("https://example.com"),
         };
 
         let request = client
@@ -46,9 +48,9 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Embed { embed } => {
+            Block::Embed { embed } => {
                 assert_eq!(embed.url, "https://example.com");
-                notionrs::object::block::Block::Embed {
+                Block::Embed {
                     embed: embed.url("https://example.com/index.html"),
                 }
             }

--- a/notionrs/tests/block/crud_equation_block.rs
+++ b/notionrs/tests/block/crud_equation_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_equation_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_equation_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,8 +18,8 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let block = notionrs::object::block::Block::Equation {
-            equation: notionrs::object::block::EquationBlock {
+        let block = Block::Equation {
+            equation: EquationBlock {
                 expression: "e=mc^2".to_string(),
             },
         };
@@ -48,9 +50,9 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Equation { equation } => {
+            Block::Equation { equation } => {
                 assert_eq!(equation.expression, "e=mc^2");
-                notionrs::object::block::Block::Equation {
+                Block::Equation {
                     equation: equation
                         .expression(r#"\overline{A \lor B} = \overline{A} \land \overline{B}"#),
                 }

--- a/notionrs/tests/block/crud_heading_block.rs
+++ b/notionrs/tests/block/crud_heading_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_heading_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_heading_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,10 +18,10 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("Heading2 !");
+        let rich_text = RichText::from("Heading2 !");
 
-        let block = notionrs::object::block::Block::Heading2 {
-            heading_2: notionrs::object::block::HeadingBlock::default()
+        let block = Block::Heading2 {
+            heading_2: HeadingBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .children(vec![])
                 .is_toggleable(true),
@@ -51,10 +53,10 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Heading2 { heading_2 } => {
+            Block::Heading2 { heading_2 } => {
                 assert_eq!(heading_2.rich_text, vec![rich_text]);
                 assert!(heading_2.is_toggleable);
-                notionrs::object::block::Block::Heading2 {
+                Block::Heading2 {
                     heading_2: heading_2.red().is_toggleable(false),
                 }
             }

--- a/notionrs/tests/block/crud_numbered_list_item_block.rs
+++ b/notionrs/tests/block/crud_numbered_list_item_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_numbered_list_item_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_numbered_list_item_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,10 +18,10 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("list item");
+        let rich_text = RichText::from("list item");
 
-        let block = notionrs::object::block::Block::NumberedListItem {
-            numbered_list_item: notionrs::object::block::NumberedListItemBlock::default()
+        let block = Block::NumberedListItem {
+            numbered_list_item: NumberedListItemBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .blue_background(),
         };
@@ -50,13 +52,13 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::NumberedListItem { numbered_list_item } => {
+            Block::NumberedListItem { numbered_list_item } => {
                 assert_eq!(numbered_list_item.rich_text, vec![rich_text]);
                 assert_eq!(
                     numbered_list_item.color,
                     notionrs::object::color::Color::BlueBackground
                 );
-                notionrs::object::block::Block::NumberedListItem {
+                Block::NumberedListItem {
                     numbered_list_item: numbered_list_item.green_background(),
                 }
             }

--- a/notionrs/tests/block/crud_paragraph_block.rs
+++ b/notionrs/tests/block/crud_paragraph_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_paragraph_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_paragraph_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,10 +18,10 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("rich text");
+        let rich_text = RichText::from("rich text");
 
-        let block = notionrs::object::block::Block::Paragraph {
-            paragraph: notionrs::object::block::ParagraphBlock::default()
+        let block = Block::Paragraph {
+            paragraph: ParagraphBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .blue_background(),
         };
@@ -50,13 +52,13 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Paragraph { paragraph } => {
+            Block::Paragraph { paragraph } => {
                 assert_eq!(paragraph.rich_text, vec![rich_text]);
                 assert_eq!(
                     paragraph.color,
                     notionrs::object::color::Color::BlueBackground
                 );
-                notionrs::object::block::Block::Paragraph {
+                Block::Paragraph {
                     paragraph: paragraph.green_background(),
                 }
             }

--- a/notionrs/tests/block/crud_quote_block.rs
+++ b/notionrs/tests/block/crud_quote_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_quote_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_quote_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,16 +18,16 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("rich text");
+        let rich_text = RichText::from("rich text");
 
-        let children = vec![notionrs::object::block::Block::Paragraph {
-            paragraph: notionrs::object::block::ParagraphBlock::default()
+        let children = vec![Block::Paragraph {
+            paragraph: ParagraphBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .blue_background(),
         }];
 
-        let block = notionrs::object::block::Block::Quote {
-            quote: notionrs::object::block::QuoteBlock::default()
+        let block = Block::Quote {
+            quote: QuoteBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .blue_background()
                 .children(children),
@@ -57,10 +59,10 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Quote { quote } => {
+            Block::Quote { quote } => {
                 assert_eq!(quote.rich_text, vec![rich_text]);
                 assert_eq!(quote.color, notionrs::object::color::Color::BlueBackground);
-                notionrs::object::block::Block::Quote {
+                Block::Quote {
                     quote: quote.green_background(),
                 }
             }

--- a/notionrs/tests/block/crud_synced_block.rs
+++ b/notionrs/tests/block/crud_synced_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_synced_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_synced_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -18,14 +20,14 @@ mod integration_tests {
 
         // origin
 
-        let block = notionrs::object::block::Block::Bookmark {
-            bookmark: notionrs::object::block::BookmarkBlock::default().url("https://example.com"),
+        let block = Block::Bookmark {
+            bookmark: BookmarkBlock::default().url("https://example.com"),
         };
 
         let children = vec![block];
 
-        let block = notionrs::object::block::Block::SyncedBlock {
-            synced_block: notionrs::object::block::SyncedBlock::default().children(children),
+        let block = Block::SyncedBlock {
+            synced_block: SyncedBlock::default().children(children),
         };
 
         let request = client
@@ -39,8 +41,8 @@ mod integration_tests {
 
         // sync
 
-        let block = notionrs::object::block::Block::SyncedBlock {
-            synced_block: notionrs::object::block::SyncedBlock::default()
+        let block = Block::SyncedBlock {
+            synced_block: SyncedBlock::default()
                 .block_id(response.results.first().unwrap().id.clone()),
         };
 

--- a/notionrs/tests/block/crud_table_block.rs
+++ b/notionrs/tests/block/crud_table_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_table_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_table_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,24 +18,24 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("rich text");
+        let rich_text = RichText::from("rich text");
 
-        let block = notionrs::object::block::Block::Table {
-            table: notionrs::object::block::TableBlock::default()
+        let block = Block::Table {
+            table: TableBlock::default()
                 .table_width(2)
                 .has_column_header(true)
                 .has_row_header(true)
                 .children(vec![
-                    notionrs::object::block::Block::TableRow {
-                        table_row: notionrs::object::block::TableRowBlock::default()
+                    Block::TableRow {
+                        table_row: TableRowBlock::default()
                             .cells(vec![vec![rich_text.clone()], vec![rich_text.clone()]]),
                     },
-                    notionrs::object::block::Block::TableRow {
-                        table_row: notionrs::object::block::TableRowBlock::default()
+                    Block::TableRow {
+                        table_row: TableRowBlock::default()
                             .cells(vec![vec![rich_text.clone()], vec![rich_text.clone()]]),
                     },
-                    notionrs::object::block::Block::TableRow {
-                        table_row: notionrs::object::block::TableRowBlock::default()
+                    Block::TableRow {
+                        table_row: TableRowBlock::default()
                             .cells(vec![vec![rich_text.clone()], vec![rich_text.clone()]]),
                     },
                 ]),

--- a/notionrs/tests/block/crud_to_do_block.rs
+++ b/notionrs/tests/block/crud_to_do_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_to_do_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_to_do_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,10 +18,10 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("list item");
+        let rich_text = RichText::from("list item");
 
-        let block = notionrs::object::block::Block::ToDo {
-            to_do: notionrs::object::block::ToDoBlock::default()
+        let block = Block::ToDo {
+            to_do: ToDoBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .checked(true),
         };
@@ -50,10 +52,10 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::ToDo { to_do } => {
+            Block::ToDo { to_do } => {
                 assert_eq!(to_do.rich_text, vec![rich_text]);
                 assert_eq!(to_do.color, notionrs::object::color::Color::Default);
-                notionrs::object::block::Block::ToDo {
+                Block::ToDo {
                     to_do: to_do.green_background(),
                 }
             }

--- a/notionrs/tests/block/crud_toggle_block.rs
+++ b/notionrs/tests/block/crud_toggle_block.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_toggle_block() -> Result<(), notionrs::error::Error> {
+    async fn crud_toggle_block() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let block_id = std::env::var("NOTION_IT_CRUD_PAGE_ID").unwrap();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -16,10 +18,10 @@ mod integration_tests {
         //
         // # --------------------------------------------------------------------------------
 
-        let rich_text = notionrs::object::rich_text::RichText::from("Toggle");
+        let rich_text = RichText::from("Toggle");
 
-        let block = notionrs::object::block::Block::Toggle {
-            toggle: notionrs::object::block::ToggleBlock::default()
+        let block = Block::Toggle {
+            toggle: ToggleBlock::default()
                 .rich_text(vec![rich_text.clone()])
                 .children(vec![]),
         };
@@ -50,9 +52,9 @@ mod integration_tests {
         // # --------------------------------------------------------------------------------
 
         let block = match response.block {
-            notionrs::object::block::Block::Toggle { toggle } => {
+            Block::Toggle { toggle } => {
                 assert_eq!(toggle.rich_text, vec![rich_text]);
-                notionrs::object::block::Block::Toggle {
+                Block::Toggle {
                     toggle: toggle.red(),
                 }
             }

--- a/notionrs/tests/comment.rs
+++ b/notionrs/tests/comment.rs
@@ -1,5 +1,7 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     // # --------------------------------------------------------------------------------
     //
     // create_comment
@@ -8,16 +10,16 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn search() -> Result<(), notionrs::error::Error> {
+    async fn search() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let page_id = std::env::var("NOTION_IT_SANDBOX_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
-        let rich_text = vec![notionrs::object::rich_text::RichText::from("Test Comment!")];
+        let rich_text = vec![RichText::from("Test Comment!")];
 
         let request = client
             .create_comment()
@@ -39,14 +41,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn retrieve_comments() -> Result<(), notionrs::error::Error> {
+    async fn retrieve_comments() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let page_id = std::env::var("NOTION_IT_SANDBOX_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let request = client.retrieve_comments().block_id(page_id);
 

--- a/notionrs/tests/database/create_database.rs
+++ b/notionrs/tests/database/create_database.rs
@@ -1,85 +1,69 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn create_database() -> Result<(), notionrs::error::Error> {
+    async fn create_database() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let page_id = std::env::var("NOTION_IT_SANDBOX_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let mut properties = std::collections::HashMap::new();
 
         properties.insert(
             "Title".to_string(),
-            notionrs::object::database::DatabaseProperty::Title(
-                notionrs::object::database::DatabaseTitleProperty::default(),
-            ),
+            DatabaseProperty::Title(DatabaseTitleProperty::default()),
         );
 
         properties.insert(
             "My Checkbox".to_string(),
-            notionrs::object::database::DatabaseProperty::Checkbox(
-                notionrs::object::database::DatabaseCheckboxProperty::default(),
-            ),
+            DatabaseProperty::Checkbox(DatabaseCheckboxProperty::default()),
         );
 
         properties.insert(
             "Created User".to_string(),
-            notionrs::object::database::DatabaseProperty::CreatedBy(
-                notionrs::object::database::DatabaseCreatedByProperty::default(),
-            ),
+            DatabaseProperty::CreatedBy(DatabaseCreatedByProperty::default()),
         );
 
         properties.insert(
             "Created Time".to_string(),
-            notionrs::object::database::DatabaseProperty::CreatedTime(
-                notionrs::object::database::DatabaseCreatedTimeProperty::default(),
-            ),
+            DatabaseProperty::CreatedTime(DatabaseCreatedTimeProperty::default()),
         );
 
         properties.insert(
             "Date".to_string(),
-            notionrs::object::database::DatabaseProperty::Date(
-                notionrs::object::database::DatabaseDateProperty::default(),
-            ),
+            DatabaseProperty::Date(DatabaseDateProperty::default()),
         );
 
         properties.insert(
             "email".to_string(),
-            notionrs::object::database::DatabaseProperty::Email(
-                notionrs::object::database::DatabaseEmailProperty::default(),
-            ),
+            DatabaseProperty::Email(DatabaseEmailProperty::default()),
         );
 
         properties.insert(
             "Files & Media".to_string(),
-            notionrs::object::database::DatabaseProperty::Files(
-                notionrs::object::database::DatabaseFilesProperty::default(),
-            ),
+            DatabaseProperty::Files(DatabaseFilesProperty::default()),
         );
 
         properties.insert(
             "formula".to_string(),
-            notionrs::object::database::DatabaseProperty::Formula(
-                notionrs::object::database::DatabaseFormulaProperty::from(r#"{{notion:block_property:BtVS:00000000-0000-0000-0000-000000000000:8994905a-074a-415f-9bcf-d1f8b4fa38e4}}/2"#),
+            DatabaseProperty::Formula(
+                DatabaseFormulaProperty::from(r#"{{notion:block_property:BtVS:00000000-0000-0000-0000-000000000000:8994905a-074a-415f-9bcf-d1f8b4fa38e4}}/2"#),
             ),
         );
 
         properties.insert(
             "Last Edited User".to_string(),
-            notionrs::object::database::DatabaseProperty::LastEditedBy(
-                notionrs::object::database::DatabaseLastEditedByProperty::default(),
-            ),
+            DatabaseProperty::LastEditedBy(DatabaseLastEditedByProperty::default()),
         );
 
         properties.insert(
             "Last Edited Time".to_string(),
-            notionrs::object::database::DatabaseProperty::LastEditedTime(
-                notionrs::object::database::DatabaseLastEditedTimeProperty::default(),
-            ),
+            DatabaseProperty::LastEditedTime(DatabaseLastEditedTimeProperty::default()),
         );
 
         let options = vec![
@@ -99,64 +83,46 @@ mod integration_tests {
 
         properties.insert(
             "Tags".to_string(),
-            notionrs::object::database::DatabaseProperty::MultiSelect(
-                notionrs::object::database::DatabaseMultiSelectProperty::default()
-                    .options(options.clone()),
+            DatabaseProperty::MultiSelect(
+                DatabaseMultiSelectProperty::default().options(options.clone()),
             ),
         );
 
         properties.insert(
             "Number".to_string(),
-            notionrs::object::database::DatabaseProperty::Number(
-                notionrs::object::database::DatabaseNumberProperty::default(),
-            ),
+            DatabaseProperty::Number(DatabaseNumberProperty::default()),
         );
 
         properties.insert(
             "People".to_string(),
-            notionrs::object::database::DatabaseProperty::People(
-                notionrs::object::database::DatabasePeopleProperty::default(),
-            ),
+            DatabaseProperty::People(DatabasePeopleProperty::default()),
         );
 
         properties.insert(
             "Phone".to_string(),
-            notionrs::object::database::DatabaseProperty::PhoneNumber(
-                notionrs::object::database::DatabasePhoneNumberProperty::default(),
-            ),
+            DatabaseProperty::PhoneNumber(DatabasePhoneNumberProperty::default()),
         );
 
         properties.insert(
             "Rich Text".to_string(),
-            notionrs::object::database::DatabaseProperty::RichText(
-                notionrs::object::database::DatabaseRichTextProperty::default(),
-            ),
+            DatabaseProperty::RichText(DatabaseRichTextProperty::default()),
         );
 
         properties.insert(
             "Select".to_string(),
-            notionrs::object::database::DatabaseProperty::Select(
-                notionrs::object::database::DatabaseSelectProperty::default()
-                    .options(options.clone()),
-            ),
+            DatabaseProperty::Select(DatabaseSelectProperty::default().options(options.clone())),
         );
 
         properties.insert(
             "URL".to_string(),
-            notionrs::object::database::DatabaseProperty::Url(
-                notionrs::object::database::DatabaseUrlProperty::default(),
-            ),
+            DatabaseProperty::Url(DatabaseUrlProperty::default()),
         );
 
         let request = client
             .create_database()
             .page_id(page_id)
-            .title(vec![notionrs::object::rich_text::RichText::from(
-                "Database Title",
-            )])
-            .description(vec![notionrs::object::rich_text::RichText::from(
-                "Description of the Database",
-            )])
+            .title(vec![RichText::from("Database Title")])
+            .description(vec![RichText::from("Description of the Database")])
             .properties(properties)
             .icon(notionrs::object::icon::Icon::Emoji(
                 notionrs::object::emoji::Emoji::from("🚧"),

--- a/notionrs/tests/database/create_database_relation.rs
+++ b/notionrs/tests/database/create_database_relation.rs
@@ -1,74 +1,62 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn create_database_relation() -> Result<(), notionrs::error::Error> {
+    async fn create_database_relation() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let page_id = std::env::var("NOTION_IT_SANDBOX_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let mut properties = std::collections::HashMap::new();
 
         properties.insert(
             "Title".to_string(),
-            notionrs::object::database::DatabaseProperty::Title(
-                notionrs::object::database::DatabaseTitleProperty::default(),
-            ),
+            DatabaseProperty::Title(DatabaseTitleProperty::default()),
         );
 
         let request = client
             .create_database()
             .page_id(page_id.clone())
-            .title(vec![notionrs::object::rich_text::RichText::from(
-                "Database Title",
-            )])
+            .title(vec![RichText::from("Database Title")])
             .properties(properties);
 
         let response = request.send().await?;
 
         let database_id = response.id;
 
-        if let notionrs::object::database::DatabaseProperty::Title(title) =
-            response.properties.get("Title").unwrap()
-        {
+        if let DatabaseProperty::Title(title) = response.properties.get("Title").unwrap() {
             let mut properties = std::collections::HashMap::new();
 
             properties.insert(
                 "Title".to_string(),
-                notionrs::object::database::DatabaseProperty::Title(
-                    notionrs::object::database::DatabaseTitleProperty::default(),
-                ),
+                DatabaseProperty::Title(DatabaseTitleProperty::default()),
             );
 
             properties.insert(
                 "One-WayRelation".to_string(),
-                notionrs::object::database::DatabaseProperty::Relation(
-                    notionrs::object::database::DatabaseRelationProperty::create_one_way_relation(
-                        database_id.clone(),
-                    ),
-                ),
+                DatabaseProperty::Relation(DatabaseRelationProperty::create_one_way_relation(
+                    database_id.clone(),
+                )),
             );
 
             properties.insert(
                 "Two-Way-Relation".to_string(),
-                notionrs::object::database::DatabaseProperty::Relation(
-                    notionrs::object::database::DatabaseRelationProperty::create_tow_way_relation(
-                        database_id.clone(),
-                        title.clone().id.unwrap(),
-                        title.clone().name,
-                    ),
-                ),
+                DatabaseProperty::Relation(DatabaseRelationProperty::create_tow_way_relation(
+                    database_id.clone(),
+                    title.clone().id.unwrap(),
+                    title.clone().name,
+                )),
             );
 
             let request = client
                 .create_database()
                 .page_id(page_id)
-                .title(vec![notionrs::object::rich_text::RichText::from(
-                    "Database Title",
-                )])
+                .title(vec![RichText::from("Database Title")])
                 .properties(properties);
 
             let response = request.send().await?;

--- a/notionrs/tests/database/query_database.rs
+++ b/notionrs/tests/database/query_database.rs
@@ -8,14 +8,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database() -> Result<(), notionrs::error::Error> {
+    async fn query_database() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
         let res = client
             .query_database()
             .database_id(database_id)
@@ -34,14 +34,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_page_size() -> Result<(), notionrs::error::Error> {
+    async fn query_database_page_size() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
         let res = client
             .query_database()
             .database_id(database_id)
@@ -61,14 +61,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_simple() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_simple() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter =
             notionrs::object::request::filter::Filter::date_before("Created time", "2024-07-01");
@@ -87,14 +87,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_checkbox() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_checkbox() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::checkbox_is_checked("Checkbox"),
@@ -115,14 +115,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_date_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_date_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::date_after("Created time", "2024-07-01"),
@@ -161,14 +161,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_files_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_files_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::files_is_empty("Files & media"),
@@ -189,14 +189,14 @@ mod integration_tests {
 
     // #[tokio::test]
     // #[serial_test::serial]
-    // async fn query_database_filter_formula_filter() -> Result<(), notionrs::error::Error> {
+    // async fn query_database_filter_formula_filter() -> Result<(), notionrs::Error> {
     //     dotenvy::dotenv().ok();
     //     dotenvy::from_path(std::path::Path::new(".env.test"))
     //         .expect("Failed to load .env.test file");
 
     //     let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-    //     let client = notionrs::client::Client::new();
+    //     let client = notionrs::Client::new();
 
     //     let filter = notionrs::object::request::filter::Filter::or(vec![
     //         notionrs::object::request::filter::Filter::formula_number_does_not_equal("formula", 0),
@@ -223,14 +223,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_multi_select_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_multi_select_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::multi_select_contains("Multi-select", "0"),
@@ -256,14 +256,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_number_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_number_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::number_does_not_equal("Number", 20),
@@ -292,14 +292,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_people_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_people_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::people_contains(
@@ -328,14 +328,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_phone_number_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_phone_number_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::phone_number_contains("Phone Number", "0"),
@@ -374,14 +374,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_relation_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_relation_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::relation_contains(
@@ -410,14 +410,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_rollup_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_rollup_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::rollup_any(
@@ -448,14 +448,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_rich_text_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_rich_text_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::rich_text_contains("Text", "0"),
@@ -482,14 +482,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_select_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_select_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::select_does_not_equal("Select", "0"),
@@ -512,14 +512,14 @@ mod integration_tests {
 
     // #[tokio::test]
     // #[serial_test::serial]
-    // async fn query_database_filter_status_filter() -> Result<(), notionrs::error::Error> {
+    // async fn query_database_filter_status_filter() -> Result<(), notionrs::Error> {
     //     dotenvy::dotenv().ok();
     //     dotenvy::from_path(std::path::Path::new(".env.test"))
     //         .expect("Failed to load .env.test file");
 
     //     let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-    //     let client = notionrs::client::Client::new();
+    //     let client = notionrs::Client::new();
 
     //     let filter = notionrs::object::request::filter::Filter::or(vec![
     //         notionrs::object::request::filter::Filter::status_does_not_equal("Status", "0"),
@@ -542,14 +542,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_timestamp_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_timestamp_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::timestamp_after("2024-07-01"),
@@ -582,14 +582,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_filter_unique_id_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_filter_unique_id_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::unique_id_does_not_equal("ID", 20),
@@ -620,14 +620,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_sort() -> Result<(), notionrs::error::Error> {
+    async fn query_database_sort() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let sorts = vec![notionrs::object::request::sort::Sort::asc("Created time")];
 

--- a/notionrs/tests/database/query_database_all.rs
+++ b/notionrs/tests/database/query_database_all.rs
@@ -8,14 +8,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
         let response = client
             .query_database_all()
             .database_id(database_id)
@@ -34,14 +34,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_page_size() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_page_size() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
         let response = client
             .query_database_all()
             .database_id(database_id)
@@ -60,14 +60,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_simple() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_simple() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter =
             notionrs::object::request::filter::Filter::date_before("Created time", "2024-07-01");
@@ -86,14 +86,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_checkbox() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_checkbox() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::checkbox_is_checked("Checkbox"),
@@ -114,14 +114,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_date_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_date_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::date_after("Created time", "2024-07-01"),
@@ -160,14 +160,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_files_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_files_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::files_is_empty("Files & media"),
@@ -188,14 +188,14 @@ mod integration_tests {
 
     // #[tokio::test]
     // #[serial_test::serial]
-    // async fn query_database_all_filter_formula_filter() -> Result<(), notionrs::error::Error> {
+    // async fn query_database_all_filter_formula_filter() -> Result<(), notionrs::Error> {
     //     dotenvy::dotenv().ok();
     //     dotenvy::from_path(std::path::Path::new(".env.test"))
     //         .expect("Failed to load .env.test file");
 
     //     let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-    //     let client = notionrs::client::Client::new();
+    //     let client = notionrs::Client::new();
 
     //     let filter = notionrs::object::request::filter::Filter::or(vec![
     //         notionrs::object::request::filter::Filter::formula_number_does_not_equal("formula", 0),
@@ -222,14 +222,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_multi_select_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_multi_select_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::multi_select_contains("Multi-select", "0"),
@@ -255,14 +255,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_number_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_number_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::number_does_not_equal("Number", 20),
@@ -291,14 +291,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_people_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_people_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::people_contains(
@@ -327,14 +327,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_phone_number_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_phone_number_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::phone_number_contains("Phone Number", "0"),
@@ -373,14 +373,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_relation_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_relation_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::relation_contains(
@@ -409,14 +409,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_rollup_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_rollup_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::rollup_any(
@@ -447,14 +447,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_rich_text_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_rich_text_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::rich_text_contains("Text", "0"),
@@ -481,14 +481,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_select_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_select_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::select_does_not_equal("Select", "0"),
@@ -511,14 +511,14 @@ mod integration_tests {
 
     // #[tokio::test]
     // #[serial_test::serial]
-    // async fn query_database_all_filter_status_filter() -> Result<(), notionrs::error::Error> {
+    // async fn query_database_all_filter_status_filter() -> Result<(), notionrs::Error> {
     //     dotenvy::dotenv().ok();
     //     dotenvy::from_path(std::path::Path::new(".env.test"))
     //         .expect("Failed to load .env.test file");
 
     //     let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-    //     let client = notionrs::client::Client::new();
+    //     let client = notionrs::Client::new();
 
     //     let filter = notionrs::object::request::filter::Filter::or(vec![
     //         notionrs::object::request::filter::Filter::status_does_not_equal("Status", "0"),
@@ -541,14 +541,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_timestamp_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_timestamp_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::timestamp_after("2024-07-01"),
@@ -581,14 +581,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_filter_unique_id_filter() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_filter_unique_id_filter() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let filter = notionrs::object::request::filter::Filter::or(vec![
             notionrs::object::request::filter::Filter::unique_id_does_not_equal("ID", 20),
@@ -619,14 +619,14 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn query_database_all_sort() -> Result<(), notionrs::error::Error> {
+    async fn query_database_all_sort() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let sorts = vec![notionrs::object::request::sort::Sort::asc("Created time")];
 

--- a/notionrs/tests/database/retrieve_database.rs
+++ b/notionrs/tests/database/retrieve_database.rs
@@ -1,12 +1,12 @@
 mod integration_tests {
 
     #[tokio::test]
-    async fn retrieve_database() -> Result<(), notionrs::error::Error> {
+    async fn retrieve_database() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
 
         let database_id = std::env::var("NOTION_IT_DATABASE_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //

--- a/notionrs/tests/database/update_database.rs
+++ b/notionrs/tests/database/update_database.rs
@@ -1,12 +1,14 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn create_database() -> Result<(), notionrs::error::Error> {
+    async fn create_database() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
 
         let page_id = std::env::var("NOTION_IT_SANDBOX_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -18,27 +20,19 @@ mod integration_tests {
 
         properties.insert(
             "Old Title".to_string(),
-            notionrs::object::database::DatabaseProperty::Title(
-                notionrs::object::database::DatabaseTitleProperty::default(),
-            ),
+            DatabaseProperty::Title(DatabaseTitleProperty::default()),
         );
 
         properties.insert(
             "My Checkbox".to_string(),
-            notionrs::object::database::DatabaseProperty::Checkbox(
-                notionrs::object::database::DatabaseCheckboxProperty::default(),
-            ),
+            DatabaseProperty::Checkbox(DatabaseCheckboxProperty::default()),
         );
 
         let request = client
             .create_database()
             .page_id(page_id)
-            .title(vec![notionrs::object::rich_text::RichText::from(
-                "Database Title",
-            )])
-            .description(vec![notionrs::object::rich_text::RichText::from(
-                "Description of the Database",
-            )])
+            .title(vec![RichText::from("Database Title")])
+            .description(vec![RichText::from("Description of the Database")])
             .properties(properties);
 
         let response = request.send().await?;
@@ -55,8 +49,8 @@ mod integration_tests {
 
         properties.insert(
             "Old Title".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::Title(
-                notionrs::object::database::DatabaseTitleProperty::default().name("New Title"),
+            Some(DatabaseProperty::Title(
+                DatabaseTitleProperty::default().name("New Title"),
             )),
         );
 
@@ -64,58 +58,50 @@ mod integration_tests {
 
         properties.insert(
             "Created User".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::CreatedBy(
-                notionrs::object::database::DatabaseCreatedByProperty::default(),
+            Some(DatabaseProperty::CreatedBy(
+                DatabaseCreatedByProperty::default(),
             )),
         );
 
         properties.insert(
             "Created Time".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::CreatedTime(
-                notionrs::object::database::DatabaseCreatedTimeProperty::default(),
+            Some(DatabaseProperty::CreatedTime(
+                DatabaseCreatedTimeProperty::default(),
             )),
         );
 
         properties.insert(
             "Date".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::Date(
-                notionrs::object::database::DatabaseDateProperty::default(),
-            )),
+            Some(DatabaseProperty::Date(DatabaseDateProperty::default())),
         );
 
         properties.insert(
             "email".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::Email(
-                notionrs::object::database::DatabaseEmailProperty::default(),
-            )),
+            Some(DatabaseProperty::Email(DatabaseEmailProperty::default())),
         );
 
         properties.insert(
             "Files & Media".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::Files(
-                notionrs::object::database::DatabaseFilesProperty::default(),
-            )),
+            Some(DatabaseProperty::Files(DatabaseFilesProperty::default())),
         );
 
         properties.insert(
             "formula".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::Formula(notionrs::object::database::DatabaseFormulaProperty::from(r#"{{notion:block_property:BtVS:00000000-0000-0000-0000-000000000000:8994905a-074a-415f-9bcf-d1f8b4fa38e4}}/2"#),)),
+            Some(DatabaseProperty::Formula(DatabaseFormulaProperty::from(r#"{{notion:block_property:BtVS:00000000-0000-0000-0000-000000000000:8994905a-074a-415f-9bcf-d1f8b4fa38e4}}/2"#),)),
         );
 
         properties.insert(
             "Last Edited User".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::LastEditedBy(
-                notionrs::object::database::DatabaseLastEditedByProperty::default(),
+            Some(DatabaseProperty::LastEditedBy(
+                DatabaseLastEditedByProperty::default(),
             )),
         );
 
         properties.insert(
             "Last Edited Time".to_string(),
-            Some(
-                notionrs::object::database::DatabaseProperty::LastEditedTime(
-                    notionrs::object::database::DatabaseLastEditedTimeProperty::default(),
-                ),
-            ),
+            Some(DatabaseProperty::LastEditedTime(
+                DatabaseLastEditedTimeProperty::default(),
+            )),
         );
 
         let options = vec![
@@ -135,62 +121,52 @@ mod integration_tests {
 
         properties.insert(
             "Tags".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::MultiSelect(
-                notionrs::object::database::DatabaseMultiSelectProperty::default()
-                    .options(options.clone()),
+            Some(DatabaseProperty::MultiSelect(
+                DatabaseMultiSelectProperty::default().options(options.clone()),
             )),
         );
 
         properties.insert(
             "Number".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::Number(
-                notionrs::object::database::DatabaseNumberProperty::default(),
-            )),
+            Some(DatabaseProperty::Number(DatabaseNumberProperty::default())),
         );
 
         properties.insert(
             "People".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::People(
-                notionrs::object::database::DatabasePeopleProperty::default(),
-            )),
+            Some(DatabaseProperty::People(DatabasePeopleProperty::default())),
         );
 
         properties.insert(
             "Phone".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::PhoneNumber(
-                notionrs::object::database::DatabasePhoneNumberProperty::default(),
+            Some(DatabaseProperty::PhoneNumber(
+                DatabasePhoneNumberProperty::default(),
             )),
         );
 
         properties.insert(
             "Rich Text".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::RichText(
-                notionrs::object::database::DatabaseRichTextProperty::default(),
+            Some(DatabaseProperty::RichText(
+                DatabaseRichTextProperty::default(),
             )),
         );
 
         properties.insert(
             "Select".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::Select(
-                notionrs::object::database::DatabaseSelectProperty::default()
-                    .options(options.clone()),
+            Some(DatabaseProperty::Select(
+                DatabaseSelectProperty::default().options(options.clone()),
             )),
         );
 
         properties.insert(
             "URL".to_string(),
-            Some(notionrs::object::database::DatabaseProperty::Url(
-                notionrs::object::database::DatabaseUrlProperty::default(),
-            )),
+            Some(DatabaseProperty::Url(DatabaseUrlProperty::default())),
         );
 
         let request = client
             .update_database()
             .database_id(response.id)
-            .title(vec![notionrs::object::rich_text::RichText::from(
-                "Database Title (changed)",
-            )])
-            .description(vec![notionrs::object::rich_text::RichText::from(
+            .title(vec![RichText::from("Database Title (changed)")])
+            .description(vec![RichText::from(
                 "Description of the Database (changed)",
             )])
             .properties(properties)

--- a/notionrs/tests/page/crud_page.rs
+++ b/notionrs/tests/page/crud_page.rs
@@ -1,14 +1,16 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_page() -> Result<(), notionrs::error::Error> {
+    async fn crud_page() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let page_id = std::env::var("NOTION_IT_SANDBOX_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         // # --------------------------------------------------------------------------------
         //
@@ -20,9 +22,7 @@ mod integration_tests {
 
         properties.insert(
             "title".to_string(),
-            notionrs::object::page::PageProperty::Title(
-                notionrs::object::page::PageTitleProperty::from("My Page Title"),
-            ),
+            PageProperty::Title(PageTitleProperty::from("My Page Title")),
         );
 
         let request = client
@@ -50,9 +50,7 @@ mod integration_tests {
 
         properties.insert(
             "title".to_string(),
-            notionrs::object::page::PageProperty::Title(
-                notionrs::object::page::PageTitleProperty::from("My Page Title (Changed)"),
-            ),
+            PageProperty::Title(PageTitleProperty::from("My Page Title (Changed)")),
         );
 
         let request = client

--- a/notionrs/tests/page/crud_page_with_database.rs
+++ b/notionrs/tests/page/crud_page_with_database.rs
@@ -1,50 +1,42 @@
 mod integration_tests {
 
+    use notionrs::prelude::*;
+
     #[tokio::test]
-    async fn crud_page_with_database() -> Result<(), notionrs::error::Error> {
+    async fn crud_page_with_database() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let page_id = std::env::var("NOTION_IT_SANDBOX_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let mut properties = std::collections::HashMap::new();
 
         properties.insert(
             "Title".to_string(),
-            notionrs::object::database::DatabaseProperty::Title(
-                notionrs::object::database::DatabaseTitleProperty::default(),
-            ),
+            DatabaseProperty::Title(DatabaseTitleProperty::default()),
         );
 
         properties.insert(
             "My Checkbox".to_string(),
-            notionrs::object::database::DatabaseProperty::Checkbox(
-                notionrs::object::database::DatabaseCheckboxProperty::default(),
-            ),
+            DatabaseProperty::Checkbox(DatabaseCheckboxProperty::default()),
         );
 
         properties.insert(
             "Date".to_string(),
-            notionrs::object::database::DatabaseProperty::Date(
-                notionrs::object::database::DatabaseDateProperty::default(),
-            ),
+            DatabaseProperty::Date(DatabaseDateProperty::default()),
         );
 
         properties.insert(
             "email".to_string(),
-            notionrs::object::database::DatabaseProperty::Email(
-                notionrs::object::database::DatabaseEmailProperty::default(),
-            ),
+            DatabaseProperty::Email(DatabaseEmailProperty::default()),
         );
 
         properties.insert(
             "Files & Media".to_string(),
-            notionrs::object::database::DatabaseProperty::Files(
-                notionrs::object::database::DatabaseFilesProperty::default(),
-            ),
+            DatabaseProperty::Files(DatabaseFilesProperty::default()),
         );
 
         let options = vec![
@@ -64,64 +56,46 @@ mod integration_tests {
 
         properties.insert(
             "Tags".to_string(),
-            notionrs::object::database::DatabaseProperty::MultiSelect(
-                notionrs::object::database::DatabaseMultiSelectProperty::default()
-                    .options(options.clone()),
+            DatabaseProperty::MultiSelect(
+                DatabaseMultiSelectProperty::default().options(options.clone()),
             ),
         );
 
         properties.insert(
             "Number".to_string(),
-            notionrs::object::database::DatabaseProperty::Number(
-                notionrs::object::database::DatabaseNumberProperty::default(),
-            ),
+            DatabaseProperty::Number(DatabaseNumberProperty::default()),
         );
 
         properties.insert(
             "People".to_string(),
-            notionrs::object::database::DatabaseProperty::People(
-                notionrs::object::database::DatabasePeopleProperty::default(),
-            ),
+            DatabaseProperty::People(DatabasePeopleProperty::default()),
         );
 
         properties.insert(
             "Phone".to_string(),
-            notionrs::object::database::DatabaseProperty::PhoneNumber(
-                notionrs::object::database::DatabasePhoneNumberProperty::default(),
-            ),
+            DatabaseProperty::PhoneNumber(DatabasePhoneNumberProperty::default()),
         );
 
         properties.insert(
             "Rich Text".to_string(),
-            notionrs::object::database::DatabaseProperty::RichText(
-                notionrs::object::database::DatabaseRichTextProperty::default(),
-            ),
+            DatabaseProperty::RichText(DatabaseRichTextProperty::default()),
         );
 
         properties.insert(
             "Select".to_string(),
-            notionrs::object::database::DatabaseProperty::Select(
-                notionrs::object::database::DatabaseSelectProperty::default()
-                    .options(options.clone()),
-            ),
+            DatabaseProperty::Select(DatabaseSelectProperty::default().options(options.clone())),
         );
 
         properties.insert(
             "URL".to_string(),
-            notionrs::object::database::DatabaseProperty::Url(
-                notionrs::object::database::DatabaseUrlProperty::default(),
-            ),
+            DatabaseProperty::Url(DatabaseUrlProperty::default()),
         );
 
         let request = client
             .create_database()
             .page_id(page_id)
-            .title(vec![notionrs::object::rich_text::RichText::from(
-                "Database Title",
-            )])
-            .description(vec![notionrs::object::rich_text::RichText::from(
-                "Description of the Database",
-            )])
+            .title(vec![RichText::from("Database Title")])
+            .description(vec![RichText::from("Description of the Database")])
             .properties(properties)
             .icon(notionrs::object::icon::Icon::Emoji(
                 notionrs::object::emoji::Emoji::from("🚧"),
@@ -144,90 +118,69 @@ mod integration_tests {
 
         properties.insert(
             "Title".to_string(),
-            notionrs::object::page::PageProperty::Title(
-                notionrs::object::page::PageTitleProperty::from("My Page Title"),
-            ),
+            PageProperty::Title(PageTitleProperty::from("My Page Title")),
         );
 
         properties.insert(
             "My Checkbox".to_string(),
-            notionrs::object::page::PageProperty::Checkbox(
-                notionrs::object::page::PageCheckboxProperty::from(true),
-            ),
+            PageProperty::Checkbox(PageCheckboxProperty::from(true)),
         );
 
         properties.insert(
             "Rich Text".to_string(),
-            notionrs::object::page::PageProperty::RichText(
-                notionrs::object::page::PageRichTextProperty::from("description"),
-            ),
+            PageProperty::RichText(PageRichTextProperty::from("description")),
         );
 
         properties.insert(
             "Date".to_string(),
-            notionrs::object::page::PageProperty::Date(
-                notionrs::object::page::PageDateProperty::from(
-                    notionrs::object::date::DateOrDateTime::DateTime(
-                        time::OffsetDateTime::parse(
-                            "2024-10-26T09:03:00.000Z",
-                            &time::format_description::well_known::Rfc3339,
-                        )
-                        .unwrap(),
-                    ),
+            PageProperty::Date(PageDateProperty::from(
+                notionrs::object::date::DateOrDateTime::DateTime(
+                    time::OffsetDateTime::parse(
+                        "2024-10-26T09:03:00.000Z",
+                        &time::format_description::well_known::Rfc3339,
+                    )
+                    .unwrap(),
                 ),
-            ),
+            )),
         );
 
         properties.insert(
             "email".to_string(),
-            notionrs::object::page::PageProperty::Email(
-                notionrs::object::page::PageEmailProperty::from("info@example.com"),
-            ),
+            PageProperty::Email(PageEmailProperty::from("info@example.com")),
         );
 
         properties.insert(
             "Files & Media".to_string(),
-            notionrs::object::page::PageProperty::Files(
-                notionrs::object::page::PageFilesProperty::from("https://example.com/file.txt"),
-            ),
+            PageProperty::Files(PageFilesProperty::from("https://example.com/file.txt")),
         );
 
         let option = notionrs::object::select::Select::from("IT");
 
         properties.insert(
             "Tags".to_string(),
-            notionrs::object::page::PageProperty::MultiSelect(
-                notionrs::object::page::PageMultiSelectProperty::default()
-                    .multi_select(vec![option]),
+            PageProperty::MultiSelect(
+                PageMultiSelectProperty::default().multi_select(vec![option]),
             ),
         );
 
         properties.insert(
             "Number".to_string(),
-            notionrs::object::page::PageProperty::Number(
-                notionrs::object::page::PageNumberProperty::from(100000),
-            ),
+            PageProperty::Number(PageNumberProperty::from(100000)),
         );
 
         properties.insert(
             "Phone".to_string(),
-            notionrs::object::page::PageProperty::PhoneNumber(
-                notionrs::object::page::PagePhoneNumberProperty::from("083-0000-0000"),
-            ),
+            PageProperty::PhoneNumber(PagePhoneNumberProperty::from("083-0000-0000")),
         );
 
         properties.insert(
             "Select".to_string(),
-            notionrs::object::page::PageProperty::Select(
-                notionrs::object::page::PageSelectProperty::from("IT"),
-            ),
+            PageProperty::Select(PageSelectProperty::from("IT")),
         );
 
         properties.insert(
             "URL".to_string(),
-            notionrs::object::page::PageProperty::Url(
-                notionrs::object::page::PageUrlProperty::from("IT"),
-            ),
+            PageProperty::Url(PageUrlProperty::from("IT")),
         );
 
         println!("{}", serde_json::to_string(&properties).unwrap());

--- a/notionrs/tests/page/get_page.rs
+++ b/notionrs/tests/page/get_page.rs
@@ -1,14 +1,14 @@
 mod integration_tests {
 
     #[tokio::test]
-    async fn get_page() -> Result<(), notionrs::error::Error> {
+    async fn get_page() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
         dotenvy::from_path(std::path::Path::new(".env.test"))
             .expect("Failed to load .env.test file");
 
         let page_id = std::env::var("NOTION_IT_SANDBOX_ID").unwrap_or_else(|_| String::new());
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let request = client.get_page().page_id(page_id);
 

--- a/notionrs/tests/search.rs
+++ b/notionrs/tests/search.rs
@@ -8,10 +8,10 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn search() -> Result<(), notionrs::error::Error> {
+    async fn search() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let request = client.search().query("").sort_timestamp_asc();
 
@@ -30,10 +30,10 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn search_page() -> Result<(), notionrs::error::Error> {
+    async fn search_page() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let request = client.search_page().query("").sort_timestamp_asc();
 
@@ -52,10 +52,10 @@ mod integration_tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn search_database() -> Result<(), notionrs::error::Error> {
+    async fn search_database() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let request = client.search_database().query("").sort_timestamp_asc();
 

--- a/notionrs/tests/user/get_self.rs
+++ b/notionrs/tests/user/get_self.rs
@@ -1,7 +1,7 @@
 mod integration_tests {
 
     use notionrs::client;
-    use notionrs::error::Error;
+    use notionrs::Error;
 
     /// This integration test cannot be run unless explicit permission
     /// for user reading is granted in the Notion API key issuance settings.

--- a/notionrs/tests/user/get_user.rs
+++ b/notionrs/tests/user/get_user.rs
@@ -1,16 +1,16 @@
 mod integration_tests {
 
     #[tokio::test]
-    async fn get_user() -> Result<(), notionrs::error::Error> {
+    async fn get_user() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let res = client.get_self().send().await?;
 
         let user_id = res.id;
 
-        let client = notionrs::client::Client::new();
+        let client = notionrs::Client::new();
 
         let request = client.get_user().user_id(user_id);
 

--- a/notionrs/tests/user/list_users.rs
+++ b/notionrs/tests/user/list_users.rs
@@ -1,7 +1,7 @@
 mod integration_tests {
 
     use notionrs::client;
-    use notionrs::error::Error;
+    use notionrs::Error;
 
     /// This integration test cannot be run unless explicit permission
     /// for user reading is granted in the Notion API key issuance settings.


### PR DESCRIPTION
## Overview

- Re-exported modules in the `prelude` module.

## Related Issues

- Fixes #231

## Changes

- Re-exported modules from the `object` modules in the `prelude` module.
- Rewrote examples tests to use `prelude` import.
- Rewrote integration tests to use `prelude` import.

## Checklist

- [x] The target branch for this PR is `main`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] Documentation has been updated if necessary.

## Additional Notes

N/A