### PR TITLE
Release: v1.0.0-alpha.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-alpha.43"
+version = "1.0.0-alpha.44"
 dependencies = [
  "dotenvy",
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-alpha.43"
+version = "1.0.0-alpha.44"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"
@@ -14,17 +14,17 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.12.15", features = [
+reqwest = { version = "0.12", features = [
     "gzip",
     "http2",
 ], default-features = false }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
-serde_plain = "1.0.2"
-thiserror = "2.0.12"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_plain = "1.0"
+thiserror = "2"
 
 notionrs_macro = "1.0.0-alpha"
-time = { version = "0.3.41", features = [
+time = { version = "0.3", features = [
     "serde",
     "parsing",
     "formatting",


### PR DESCRIPTION
## Dependency Updates

* Allowed patch version differences for greater flexibility.
* Previously, both `gzip` and `brotli` were enabled as features for `reqwest`, but since the Notion API only supports `gzip`, it is now fixed to use `gzip` only.
* Enabled HTTP/2 support in `reqwest`, which was previously disabled[^1].

[^1]: While the Notion API also supports HTTP/3, `reqwest` does not yet offer stable support for it. Additionally, since HTTP/3 uses UDP, it will be offered as an optional feature in the future.
