### PR TITLE
Add extended link metadata fields to LinkMention struct

### DIFF
--- a/notionrs/src/object/rich_text/mention.rs
+++ b/notionrs/src/object/rich_text/mention.rs
@@ -89,6 +89,16 @@ crate::impl_from_as_ref!(LinkPreviewMention, url);
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default, notionrs_macro::Setter)]
 pub struct LinkMention {
     pub href: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub link_author: Option<String>,
+    pub link_provider: Option<String>,
+    pub thumbnail_url: Option<String>,
+    pub icon_url: Option<String>,
+    pub iframe_url: Option<String>,
+    pub height: Option<u32>,
+    pub padding: Option<u32>,
+    pub padding_top: Option<u32>,
 }
 crate::impl_display_from_string_field!(LinkMention, href);
 crate::impl_from_as_ref!(LinkMention, href);


### PR DESCRIPTION
## Overview

This Pull Request updates the schema in response to changes introduced in [notion-sdk-js v2.2.17](https://github.com/makenotion/notion-sdk-js/compare/eed58030649895b95ab9b97e2959f77bab19cd62...v2.2.17). The update ensures compatibility with the latest version of the Notion API SDK.

## Related Issues

N/A

## Changes

* Added optional fields to the schema:

  * `title: Option<String>`
  * `description: Option<String>`
  * `link_author: Option<String>`
  * `link_provider: Option<String>`
  * `thumbnail_url: Option<String>`
  * `icon_url: Option<String>`
  * `iframe_url: Option<String>`
  * `height: Option<u32>`
  * `padding: Option<u32>`
  * `padding_top: Option<u32>`

## Checklist

* [x] The target branch for this PR is `main`.
* [x] Unit tests have been added.
* [x] All unit tests pass.
* [x] Documentation has been updated if necessary.

## Additional Notes

This change aligns our schema with the new structure expected by the latest `notion-sdk-js`.
