### PR TITLE
chore: bump notionrs version to v1.0.0-alpha.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-alpha.44"
+version = "1.0.0-alpha.45"
 dependencies = [
  "dotenvy",
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-alpha.44"
+version = "1.0.0-alpha.45"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"


### PR DESCRIPTION
## Changed

- Updated schema to match `notion-sdk-js` v2.2.17.
- Added new optional fields: `title`, `description`, `link_author`, `link_provider`, `thumbnail_url`, `icon_url`, `iframe_url`, `height`, `padding`, and `padding_top`.
