### PR TITLE
chore: update notionrs to version 1.0.0-beta.2 and adjust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "dotenvy",
  "notionrs-schema 1.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ As part of the alpha release, the following features are available. Please note 
 Below is a basic example. (More detailed documentation is coming soon, so please stay tuned!)
 
 ```rs
-use notionrs::prelude::*;
+use notionrs_schema::prelude::*;
 use notionrs::{Client, Error};
 
 #[tokio::main]

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"


### PR DESCRIPTION
## Features

* Extracted API schema definitions (e.g., request/response structs, enums) into a new crate [`notionrs-schema`](https://docs.rs/notionrs-schema).
* This separation reduces the frequency of breaking changes in `notionrs` when the Notion API evolves.

## Refactoring

* Updated integration tests and internal references to use the external `notionrs-schema` crate.
