### PR TITLE
fix: fix invalid formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ version = "1.0.0-beta.3"
 dependencies = [
  "dotenvy",
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "notionrs_types 1.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notionrs_types 1.0.0-rc.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -762,22 +762,22 @@ dependencies = [
 [[package]]
 name = "notionrs_types"
 version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c8edef7e97723947e28f8133bdd905528a35b0e19a63050c4297c74219a32a"
 dependencies = [
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "serde_json",
  "serde_plain",
  "time",
 ]
 
 [[package]]
 name = "notionrs_types"
-version = "1.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c8edef7e97723947e28f8133bdd905528a35b0e19a63050c4297c74219a32a"
+version = "1.0.0-rc.2"
 dependencies = [
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
+ "serde_json",
  "serde_plain",
  "time",
 ]

--- a/notionrs_types/Cargo.toml
+++ b/notionrs_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs_types"
 description = "Shared schema definitions for the Notion API used by the notionrs ecosystem."
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"

--- a/notionrs_types/src/object/date.rs
+++ b/notionrs_types/src/object/date.rs
@@ -28,20 +28,39 @@ pub enum DateOrDateTime {
     #[serde(with = "time::serde::rfc3339")]
     DateTime(time::OffsetDateTime),
 }
-
 impl std::fmt::Display for DateOrDateTime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let date = match self {
+        let text = match self {
             DateOrDateTime::Date(date) => date.to_string(),
-            DateOrDateTime::DateTime(offset_date_time) => offset_date_time.to_string(),
+            DateOrDateTime::DateTime(offset_date_time) => offset_date_time
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or_else(|_| "<invalid datetime>".into()),
         };
-
-        write!(f, "{}", date)
+        write!(f, "{}", text)
     }
 }
 
 impl Default for DateOrDateTime {
     fn default() -> Self {
         Self::DateTime(time::OffsetDateTime::now_utc())
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+
+    use super::*;
+
+    #[test]
+    fn display_date_time_is_rfc3339() {
+        let value: DateOrDateTime =
+            DateOrDateTime::DateTime(time::macros::datetime!(2024-05-01 12:00 UTC));
+        assert_eq!(value.to_string(), "2024-05-01T12:00:00Z");
+    }
+
+    #[test]
+    fn display_date_is_iso8601() {
+        let value = DateOrDateTime::Date(time::macros::date!(2024 - 05 - 01));
+        assert_eq!(value.to_string(), "2024-05-01");
     }
 }


### PR DESCRIPTION
## Overview

- Fixed invalid datetime formatting.

## Related Issues

N/A

## Changes

- Fixed incorrect RFC 3339 datetime formatting in the `DateOrDateTime` enum.

## Checklist

- [x] The target branch for this PR is `main`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] Documentation has been updated if necessary.

## Additional Notes

N/A
