### PR TITLE
feat: add workspace_limits to BotOwner and define WorkspaceLimits struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs_types"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "notionrs_macro 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",

--- a/notionrs_types/Cargo.toml
+++ b/notionrs_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs_types"
 description = "Shared schema definitions for the Notion API used by the notionrs ecosystem."
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"

--- a/notionrs_types/src/object/user.rs
+++ b/notionrs_types/src/object/user.rs
@@ -119,7 +119,10 @@ mod unit_tests {
                     "type": "workspace",
                     "workspace": true
                 },
-                "workspace_name": "notionrs integration test"
+                "workspace_name": "notionrs integration test",
+                "workspace_limits": {
+                    "max_file_upload_size_in_bytes": 5368709120
+                }
             }
         }
         "#;

--- a/notionrs_types/src/object/user.rs
+++ b/notionrs_types/src/object/user.rs
@@ -66,6 +66,16 @@ pub struct BotOwner {
 
     /// Whether the bot's owner is the workspace.
     pub workspace: bool,
+
+    /// Information about the limits and restrictions that apply to the bot's workspace.
+    pub workspace_limits: Option<WorkspaceLimits>,
+}
+
+/// Information about the limits and restrictions that apply to the bot's workspace.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default, notionrs_macro::Setter)]
+pub struct WorkspaceLimits {
+    /// The maximum allowable size of a file upload, in bytes.
+    pub max_file_upload_size_in_bytes: u64,
 }
 
 impl Default for User {


### PR DESCRIPTION
## Overview

- Adapted from notion-sdk-js@3.1.2 version upgrade

## Related Issues

- Fixes #281

## Changes

- Added new `workspace_limits` field to `BotOwner`.

## Checklist

- [x] The target branch for this PR is `main`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] Documentation has been updated if necessary.

## Additional Notes

- See <https://developers.notion.com/reference/user#bots>
