### PR TITLE
chore: bump version to 1.0.0-beta.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-trait",
  "bytes",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"

--- a/notionrs/src/client/page/update_page.rs
+++ b/notionrs/src/client/page/update_page.rs
@@ -10,6 +10,8 @@ pub struct UpdatePageClient {
     pub(crate) properties:
         std::collections::HashMap<String, notionrs_types::object::page::PageProperty>,
 
+    pub(crate) in_trash: Option<bool>,
+
     pub(crate) icon: Option<notionrs_types::object::icon::Icon>,
 
     pub(crate) cover: Option<notionrs_types::object::file::File>,
@@ -19,6 +21,9 @@ pub struct UpdatePageClient {
 pub struct UpdatePageRequestBody {
     pub(crate) properties:
         std::collections::HashMap<String, notionrs_types::object::page::PageProperty>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) in_trash: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) icon: Option<notionrs_types::object::icon::Icon>,
@@ -37,6 +42,7 @@ impl UpdatePageClient {
 
         let request_body_struct = UpdatePageRequestBody {
             properties: self.properties,
+            in_trash: self.in_trash,
             icon: self.icon,
             cover: self.cover,
         };


### PR DESCRIPTION
## Features

- Added support for the `in_trash` field in the `updatePage` API to allow soft-deleting or restoring pages via the Notion API.
