### PR TITLE
chore: bump crate version to 1.0.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs_types"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "notionrs_macro 1.0.0-alpha.1",
  "serde",

--- a/notionrs_types/Cargo.toml
+++ b/notionrs_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs_types"
 description = "Shared schema definitions for the Notion API used by the notionrs ecosystem."
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 edition = "2024"
 authors = ["Chomolungma Shirayuki"]
 repository = "https://github.com/46ki75/notionrs"


### PR DESCRIPTION
## 🔧 Bug Fixes

**Made CalloutBlock icon field optional**

- Changed `CalloutBlock.icon` to `Option<Icon>` to handle cases where callout blocks don't have icons
- **Breaking Change**: Update code that accesses `icon` field directly