### PR TITLE
chore: bump crate version to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Ikuma Yamashita"]
 repository = "https://github.com/46ki75/notionrs"


### PR DESCRIPTION
## Bug Fixes

- Fixed `create_page` function to adapt to the new Notion API.
