### PR TITLE
feat(#599): add `position` field to insert_content (notion-sdk-js v5.22.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ src/bin/*
 
 lcov.info
 
+notes/
+
 # Node.js
 node_modules/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bytes",
  "dotenvy",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs_types"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "notionrs_macro",
  "serde",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "0.26.0"
+version = "0.27.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }
@@ -15,7 +15,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-notionrs_types = { version = "0.19.0", path = "../notionrs_types" }
+notionrs_types = { version = "0.20.0", path = "../notionrs_types" }
 notionrs_macro = { version = "0.4.0", path = "../notionrs_macro" }
 
 reqwest = { workspace = true }

--- a/notionrs/src/client/page/update_page_markdown.rs
+++ b/notionrs/src/client/page/update_page_markdown.rs
@@ -58,8 +58,30 @@ pub struct InsertContentPayload {
 
     /// Selection of existing content to insert after, using the ellipsis format
     /// ("start text...end text"). Omit to append at the end of the page.
+    ///
+    /// Mutually exclusive with `position`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<String>,
+
+    /// Explicit position at which to insert the content (either the start
+    /// or the end of the page). Added in `notion-sdk-js` v5.22.0.
+    ///
+    /// Mutually exclusive with `after`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<InsertContentPosition>,
+}
+
+/// Position at which to insert content via the `insert_content` operation.
+///
+/// Mutually exclusive with `InsertContentPayload::after`.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InsertContentPosition {
+    /// Insert the content at the start of the page.
+    Start,
+
+    /// Insert the content at the end of the page.
+    End,
 }
 
 /// Payload for the `replace_content_range` operation.
@@ -127,6 +149,7 @@ impl UpdatePageMarkdownClient {
             insert_content: InsertContentPayload {
                 content: content.as_ref().to_string(),
                 after: None,
+                position: None,
             },
         });
         self
@@ -144,6 +167,26 @@ impl UpdatePageMarkdownClient {
             insert_content: InsertContentPayload {
                 content: content.as_ref().to_string(),
                 after: Some(after.as_ref().to_string()),
+                position: None,
+            },
+        });
+        self
+    }
+
+    /// Set the body to an `insert_content` operation that inserts at the explicit
+    /// `position` (start or end of the page). Added in `notion-sdk-js` v5.22.0.
+    ///
+    /// `position` is mutually exclusive with `after`.
+    pub fn insert_content_at(
+        mut self,
+        content: impl AsRef<str>,
+        position: InsertContentPosition,
+    ) -> Self {
+        self.body = Some(UpdatePageMarkdownBody::InsertContent {
+            insert_content: InsertContentPayload {
+                content: content.as_ref().to_string(),
+                after: None,
+                position: Some(position),
             },
         });
         self
@@ -298,6 +341,7 @@ mod tests {
             insert_content: InsertContentPayload {
                 content: "# New Heading\n\nSome text.".to_string(),
                 after: None,
+                position: None,
             },
         };
 
@@ -305,6 +349,7 @@ mod tests {
         assert_eq!(json["type"], "insert_content");
         assert_eq!(json["insert_content"]["content"], "# New Heading\n\nSome text.");
         assert!(json["insert_content"].get("after").is_none());
+        assert!(json["insert_content"].get("position").is_none());
     }
 
     #[test]
@@ -313,12 +358,60 @@ mod tests {
             insert_content: InsertContentPayload {
                 content: "New content".to_string(),
                 after: Some("start...end".to_string()),
+                position: None,
             },
         };
 
         let json = serde_json::to_value(&body).expect("Failed to serialize");
         assert_eq!(json["type"], "insert_content");
         assert_eq!(json["insert_content"]["after"], "start...end");
+        assert!(json["insert_content"].get("position").is_none());
+    }
+
+    #[test]
+    fn serialize_insert_content_with_position_start() {
+        let body = UpdatePageMarkdownBody::InsertContent {
+            insert_content: InsertContentPayload {
+                content: "Prepend me".to_string(),
+                after: None,
+                position: Some(InsertContentPosition::Start),
+            },
+        };
+
+        let json = serde_json::to_value(&body).expect("Failed to serialize");
+        assert_eq!(json["type"], "insert_content");
+        assert_eq!(json["insert_content"]["content"], "Prepend me");
+        assert_eq!(json["insert_content"]["position"]["type"], "start");
+        assert!(json["insert_content"].get("after").is_none());
+    }
+
+    #[test]
+    fn serialize_insert_content_with_position_end() {
+        let body = UpdatePageMarkdownBody::InsertContent {
+            insert_content: InsertContentPayload {
+                content: "Append me".to_string(),
+                after: None,
+                position: Some(InsertContentPosition::End),
+            },
+        };
+
+        let json = serde_json::to_value(&body).expect("Failed to serialize");
+        assert_eq!(json["insert_content"]["position"]["type"], "end");
+    }
+
+    #[test]
+    fn builder_insert_content_at_sets_position() {
+        let client = UpdatePageMarkdownClient::default()
+            .insert_content_at("Hi", InsertContentPosition::Start);
+
+        match client.body.expect("body should be set") {
+            UpdatePageMarkdownBody::InsertContent { insert_content } => {
+                assert_eq!(insert_content.content, "Hi");
+                assert!(insert_content.after.is_none());
+                assert_eq!(insert_content.position, Some(InsertContentPosition::Start));
+            }
+            _ => panic!("Expected InsertContent variant"),
+        }
     }
 
     #[test]
@@ -459,6 +552,30 @@ mod tests {
             UpdatePageMarkdownBody::InsertContent { insert_content } => {
                 assert_eq!(insert_content.content, "hello");
                 assert!(insert_content.after.is_none());
+                assert!(insert_content.position.is_none());
+            }
+            _ => panic!("Expected InsertContent variant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_insert_content_with_position() {
+        let json = r#"
+        {
+            "type": "insert_content",
+            "insert_content": {
+                "content": "hello",
+                "position": { "type": "start" }
+            }
+        }
+        "#;
+
+        let body: UpdatePageMarkdownBody =
+            serde_json::from_str(json).expect("Failed to deserialize");
+        match body {
+            UpdatePageMarkdownBody::InsertContent { insert_content } => {
+                assert_eq!(insert_content.content, "hello");
+                assert_eq!(insert_content.position, Some(InsertContentPosition::Start));
             }
             _ => panic!("Expected InsertContent variant"),
         }

--- a/notionrs/tests/mutable/page/page_markdown.rs
+++ b/notionrs/tests/mutable/page/page_markdown.rs
@@ -45,6 +45,58 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn update_page_markdown_insert_content_at_start() -> Result<(), notionrs::Error> {
+        dotenvy::dotenv().ok();
+
+        let notion_api_key = std::env::var("NOTION_API_KEY_MUTABLE").unwrap();
+        let client = notionrs::Client::new(notion_api_key);
+
+        // create a page
+        let mut properties = std::collections::HashMap::new();
+        properties.insert(
+            "title".to_string(),
+            PageProperty::Title(PageTitleProperty::from(
+                "Markdown Insert Content At Start Test",
+            )),
+        );
+
+        let page = client
+            .create_page::<std::collections::HashMap<String, PageProperty>>()
+            .properties(properties)
+            .page_id(PAGE_ID)
+            .send()
+            .await?;
+
+        // insert initial content (appended at end by default)
+        client
+            .update_page_markdown()
+            .page_id(&page.id)
+            .insert_content("Original first line.")
+            .send()
+            .await?;
+
+        // prepend new content at the start of the page
+        let response = client
+            .update_page_markdown()
+            .page_id(&page.id)
+            .insert_content_at(
+                "# Prepended Heading\n\nPrepended paragraph.",
+                notionrs::client::page::update_page_markdown::InsertContentPosition::Start,
+            )
+            .send()
+            .await?;
+
+        assert_eq!(response.object, "page_markdown");
+        assert_eq!(response.id, page.id);
+        assert!(!response.markdown.is_empty());
+
+        // cleanup
+        client.delete_block().block_id(&page.id).send().await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn update_page_markdown_replace_content() -> Result<(), notionrs::Error> {
         dotenvy::dotenv().ok();
 

--- a/notionrs_types/Cargo.toml
+++ b/notionrs_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs_types"
 description = "Shared schema definitions for the Notion API used by the notionrs ecosystem."
-version = "0.19.0"
+version = "0.20.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }


### PR DESCRIPTION
## Overview

- `notion-sdk-js` v5.22.0 ([release notes](https://github.com/makenotion/notion-sdk-js/releases/tag/v5.22.0), [PR #720](https://github.com/makenotion/notion-sdk-js/pull/720)) adds a new optional `position` field to the `insert_content` params of the `PATCH /v1/pages/{page_id}/markdown` endpoint. `position` is a discriminated union of `{ "type": "start" }` and `{ "type": "end" }`, and is mutually exclusive with the existing `after` selector. This PR mirrors that schema change in `notionrs`.

## Related Issues

- Closes #599

## Changes

- Add `InsertContentPosition` enum (`Start` / `End`) — a `#[serde(tag = "type", rename_all = "snake_case")]` discriminated union matching the SDK schema.
- Add `position: Option<InsertContentPosition>` to `InsertContentPayload` (serialized only when set, to remain compatible with existing usage and the `after`-mutual-exclusivity rule).
- Add `UpdatePageMarkdownClient::insert_content_at(content, position)` builder helper.
- Update existing `insert_content` / `insert_content_after` builders to set `position: None`.
- Unit tests: serialize/deserialize the new `position` variants, and a builder test for `insert_content_at`.
- Integration test: `update_page_markdown_insert_content_at_start` — prepends content to a freshly-created page via `InsertContentPosition::Start`.

## Checklist

- [x] The target branch for this PR is `main`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [ ] If you added new structs to `notionrs_types`, ensure you re-export the structs in the `prelude` module. — N/A (new types live in `notionrs::client::page::update_page_markdown`, alongside the rest of the request payload structs).
- [ ] Documentation has been updated if necessary. — Inline rustdoc on the new types/fields is included; no other docs reference `insert_content` params.
- [ ] Release tags have been added if needed.

## Additional Notes

- `position` is serialized only when `Some(_)`, so existing call sites (`insert_content` / `insert_content_after`) produce identical JSON to before this change.
- The integration test requires `NOTION_API_KEY_MUTABLE` and was not executed in this environment (no credentials available); it follows the same setup/cleanup pattern as the sibling `update_page_markdown_*` integration tests in `notionrs/tests/mutable/page/page_markdown.rs`.