### PR TITLE
docs(agents): record fmt/clippy gotchas and the async-task envelope pitfall

### DIFF
--- a/.claude/rules/async-task.md
+++ b/.claude/rules/async-task.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "notionrs_types/src/object/async_task.rs"
+  - "notionrs/src/client/async_task/**"
+  - "**/*allow_async*"
+---
+
+# Async Task Responses
+
+- `AsyncTaskResponse::Succeeded`/`Failed`'s own `id`/`object` fields describe
+  the task envelope itself (`object` is always `"async_task"`, `id` is the
+  task's own ID) — not the underlying operation's result. The real fields
+  (e.g. a created page's `id`/`markdown`) are nested inside `result`, a raw
+  `HashMap<String, serde_json::Value>`. Reading `succeeded.id`/`succeeded.object`
+  when you want the operation's result is an easy, silent mistake — it only
+  surfaced in this project by actually running an `allow_async(true)` request
+  against the live API and observing Notion genuinely go async.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ MSRV (Minimum Supported Rust Version) is specified in `Cargo.toml` and `rust-too
 
 - `notionrs` → without prefix (e.g., v0.1.0)
 - `notionrs_macro`, `notionrs_types`, `notionrs_webhooks` → with prefix (e.g., macro-v0.1.0, webhooks-v0.2.0)
+- Every release bumps only the minor version (`0.Y.0`), regardless of whether it includes breaking changes.
 
 ## Test Coverage
 
@@ -42,3 +43,8 @@ just coverage   # cargo llvm-cov --show-missing-lines
 ```
 
 Treat coverage % as a guardrail (fail CI on drops), not a target to maximize.
+
+## Formatting & Linting
+
+- `cargo fmt --all -- --check` has pre-existing drift across many unrelated files (local rustfmt output differs from whatever produced the checked-in formatting) — format only the files you actually touched; don't reformat the repo as a side effect of a scoped change.
+- `cargo clippy --workspace` cannot currently complete: a non-semver `since` in a `#[deprecated(...)]` on `FileUpload::archived` (`notionrs_types/src/object/file_upload.rs`) hard-errors the clippy driver for every dependent crate (tracked in #629). `cargo build`/`check`/`test` are unaffected — use those to verify, and check a clean `main` checkout before assuming a fmt/clippy failure is something you introduced.


### PR DESCRIPTION
## Overview

Captures two things learned while working on #627/#630 that would otherwise cost a future session (human or AI agent) the same time to rediscover.

## Related Issues

- N/A — general project-memory follow-up, not tied to a specific issue.

## Changes

- **`AGENTS.md`**:
  - `cargo fmt --all -- --check` has pre-existing drift across many unrelated files (local rustfmt output vs. whatever produced the checked-in formatting) — a scoped change shouldn't reformat the whole repo as a side effect.
  - `cargo clippy --workspace` currently can't complete: a non-semver `since` in a `#[deprecated(...)]` on `FileUpload::archived` hard-errors the clippy driver for every dependent crate (tracked in #629). `cargo build`/`check`/`test` are unaffected.
  - Recorded the existing versioning convention observed via `gh release list`: every release bumps only the minor version, regardless of whether it includes breaking changes.
- **`.claude/rules/async-task.md`** (new, path-scoped to `async_task`/`allow_async` files): `AsyncTaskResponse::Succeeded`/`Failed`'s own `id`/`object` fields describe the task envelope itself, not the underlying operation's result (nested inside `result`). This is an easy, silent mistake — it's exactly what broke `update_page_markdown_allow_async.rs` in #630 until the test was actually run against the live API.

## Checklist

- [x] The target branch for this PR is `main`.
- [ ] Unit tests have been added.
- [ ] All unit tests pass.
- [ ] If you added new structs to `notionrs_types`, ensure you re-export the structs in the `prelude` module.
- [x] Documentation has been updated if necessary.
- [ ] Release tags have been added if needed.

## Additional Notes

Docs-only change; no code or test changes.