### PR TITLE
feat(search): support trash filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "bytes",
  "dotenvy",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs_types"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "notionrs_macro",
  "serde",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "0.28.0"
+version = "0.29.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }
@@ -15,7 +15,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-notionrs_types = { version = "0.21.0", path = "../notionrs_types" }
+notionrs_types = { version = "0.22.0", path = "../notionrs_types" }
 notionrs_macro = { version = "0.4.0", path = "../notionrs_macro" }
 
 reqwest = { workspace = true }

--- a/notionrs/src/client/search/mod.rs
+++ b/notionrs/src/client/search/mod.rs
@@ -22,7 +22,7 @@ pub struct SearchRequestBody {
     pub(crate) query: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) filter: Option<notionrs_types::object::request::search::SearchFilter>,
+    pub(crate) filter: Option<notionrs_types::object::request::search::SearchFilterRequest>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) sort: Option<notionrs_types::object::request::search::SearchSort>,
@@ -107,22 +107,88 @@ impl SearchClient {
     /// Restricts search results to only database types.
     /// It is recommended to use the search_database method, which returns results that are not in an enum format.
     pub fn filter_database(self) -> Self {
-        self.filter(notionrs_types::object::request::search::SearchFilter::database())
+        self.filter_object(notionrs_types::object::request::search::SearchFilterType::DataSource)
     }
 
     /// Restricts search results to only page types.
     /// It is recommended to use the search_page method, which returns results that are not in an enum format.
     pub fn filter_page(self) -> Self {
-        self.filter(notionrs_types::object::request::search::SearchFilter::page())
+        self.filter_object(notionrs_types::object::request::search::SearchFilterType::Page)
     }
 
-    fn filter(mut self, filter: notionrs_types::object::request::search::SearchFilter) -> Self {
-        self.body.filter = Some(filter);
+    /// Restricts search results to trashed or live objects.
+    pub fn filter_in_trash(mut self, in_trash: bool) -> Self {
+        self.body.filter = Some(
+            self.body
+                .filter
+                .unwrap_or_else(|| {
+                    notionrs_types::object::request::search::SearchFilterRequest::trash(in_trash)
+                })
+                .in_trash(in_trash),
+        );
+        self
+    }
+
+    fn filter_object(
+        mut self,
+        value: notionrs_types::object::request::search::SearchFilterType,
+    ) -> Self {
+        let in_trash = match self.body.filter {
+            Some(notionrs_types::object::request::search::SearchFilterRequest::Object {
+                in_trash,
+                ..
+            }) => in_trash,
+            Some(notionrs_types::object::request::search::SearchFilterRequest::InTrash {
+                in_trash,
+            }) => Some(in_trash),
+            None => None,
+        };
+        self.body.filter = Some(
+            notionrs_types::object::request::search::SearchFilterRequest::Object {
+                value,
+                property: String::from("object"),
+                in_trash,
+            },
+        );
         self
     }
 
     fn sort(mut self, sort: notionrs_types::object::request::search::SearchSort) -> Self {
         self.body.sort = Some(sort);
         self
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn filter_in_trash_serializes_supported_filter_shapes() {
+        let filter = SearchClient::default().filter_in_trash(true).body.filter;
+        assert_eq!(
+            serde_json::to_value(filter).unwrap(),
+            serde_json::json!({"in_trash": true})
+        );
+
+        let filter = SearchClient::default()
+            .filter_page()
+            .filter_in_trash(true)
+            .body
+            .filter;
+        assert_eq!(
+            serde_json::to_value(filter).unwrap(),
+            serde_json::json!({"property": "object", "value": "page", "in_trash": true})
+        );
+
+        let filter = SearchClient::default()
+            .filter_in_trash(false)
+            .filter_database()
+            .body
+            .filter;
+        assert_eq!(
+            serde_json::to_value(filter).unwrap(),
+            serde_json::json!({"property": "object", "value": "data_source", "in_trash": false})
+        );
     }
 }

--- a/notionrs/src/client/search/search_database.rs
+++ b/notionrs/src/client/search/search_database.rs
@@ -17,6 +17,9 @@ pub struct SearchDatabaseClient {
     /// The amount of data retrieved in one query.
     /// If not specified, the default is 100.
     pub(crate) page_size: Option<u32>,
+
+    #[setter(skip)]
+    pub(crate) in_trash: Option<bool>,
 }
 
 crate::impl_paginate!(
@@ -30,7 +33,7 @@ pub struct SearchDatabaseRequestBody {
     pub(crate) query: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) filter: Option<notionrs_types::object::request::search::SearchFilter>,
+    pub(crate) filter: Option<notionrs_types::object::request::search::SearchFilterRequest>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) sort: Option<notionrs_types::object::request::search::SearchSort>,
@@ -55,7 +58,13 @@ impl SearchDatabaseClient {
 
         let request_body = serde_json::to_string(&SearchDatabaseRequestBody {
             query: self.query,
-            filter: Some(notionrs_types::object::request::search::SearchFilter::database()),
+            filter: Some(match self.in_trash {
+                Some(in_trash) => {
+                    notionrs_types::object::request::search::SearchFilterRequest::database()
+                        .in_trash(in_trash)
+                }
+                None => notionrs_types::object::request::search::SearchFilterRequest::database(),
+            }),
             sort: self.sort,
             start_cursor: self.start_cursor,
             page_size: self.page_size,
@@ -103,5 +112,11 @@ impl SearchDatabaseClient {
     /// Sort by relevance to the search query.
     pub fn sort_relevance(self) -> Self {
         self.sort(notionrs_types::object::request::search::SearchSort::relevance())
+    }
+
+    /// Restricts search results to trashed or live data sources.
+    pub fn filter_in_trash(mut self, in_trash: bool) -> Self {
+        self.in_trash = Some(in_trash);
+        self
     }
 }

--- a/notionrs/src/client/search/search_page.rs
+++ b/notionrs/src/client/search/search_page.rs
@@ -17,6 +17,9 @@ pub struct SearchPageClient {
     /// The amount of data retrieved in one query.
     /// If not specified, the default is 100.
     pub(crate) page_size: Option<u32>,
+
+    #[setter(skip)]
+    pub(crate) in_trash: Option<bool>,
 }
 
 crate::impl_paginate!(SearchPageClient, notionrs_types::object::page::PageResponse);
@@ -27,7 +30,7 @@ pub struct SearchPageRequestBody {
     pub(crate) query: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) filter: Option<notionrs_types::object::request::search::SearchFilter>,
+    pub(crate) filter: Option<notionrs_types::object::request::search::SearchFilterRequest>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) sort: Option<notionrs_types::object::request::search::SearchSort>,
@@ -50,7 +53,13 @@ impl SearchPageClient {
 
         let request_body = serde_json::to_string(&SearchPageRequestBody {
             query: self.query,
-            filter: Some(notionrs_types::object::request::search::SearchFilter::page()),
+            filter: Some(match self.in_trash {
+                Some(in_trash) => {
+                    notionrs_types::object::request::search::SearchFilterRequest::page()
+                        .in_trash(in_trash)
+                }
+                None => notionrs_types::object::request::search::SearchFilterRequest::page(),
+            }),
             sort: self.sort,
             start_cursor: self.start_cursor,
             page_size: self.page_size,
@@ -98,5 +107,11 @@ impl SearchPageClient {
     /// Sort by relevance to the search query.
     pub fn sort_relevance(self) -> Self {
         self.sort(notionrs_types::object::request::search::SearchSort::relevance())
+    }
+
+    /// Restricts search results to trashed or live pages.
+    pub fn filter_in_trash(mut self, in_trash: bool) -> Self {
+        self.in_trash = Some(in_trash);
+        self
     }
 }

--- a/notionrs/tests/readonly/search.rs
+++ b/notionrs/tests/readonly/search.rs
@@ -46,6 +46,28 @@ mod integration_tests {
 
     // # --------------------------------------------------------------------------------
     //
+    // search (trashed content)
+    //
+    // # --------------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn search_in_trash() -> Result<(), notionrs::Error> {
+        dotenvy::dotenv().ok();
+
+        let notion_api_key = std::env::var("NOTION_API_KEY_READONLY").unwrap();
+        let client = notionrs::Client::new(notion_api_key);
+
+        let request = client.search().query("").filter_in_trash(true);
+
+        let response = request.send().await?;
+
+        println!("{}", serde_json::to_string(&response)?);
+
+        Ok(())
+    }
+
+    // # --------------------------------------------------------------------------------
+    //
     // search_page
     //
     // # --------------------------------------------------------------------------------

--- a/notionrs_types/Cargo.toml
+++ b/notionrs_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs_types"
 description = "Shared schema definitions for the Notion API used by the notionrs ecosystem."
-version = "0.21.0"
+version = "0.22.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/notionrs_types/src/object/request/search.rs
+++ b/notionrs_types/src/object/request/search.rs
@@ -47,6 +47,73 @@ impl SearchFilter {
     }
 }
 
+/// A search filter that can restrict results by object type, trash status, or both.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum SearchFilterRequest {
+    /// Restricts search results to pages or data sources, optionally in the trash.
+    Object {
+        /// The value of the property to filter the results by.
+        value: SearchFilterType,
+
+        /// Always `"object"`.
+        property: String,
+
+        /// Whether to return only trashed objects.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        in_trash: Option<bool>,
+    },
+
+    /// Restricts search results to trashed or live objects without limiting their type.
+    InTrash {
+        /// Whether to return only trashed objects.
+        in_trash: bool,
+    },
+}
+
+impl SearchFilterRequest {
+    pub fn page() -> Self {
+        Self::Object {
+            value: SearchFilterType::Page,
+            property: String::from("object"),
+            in_trash: None,
+        }
+    }
+
+    pub fn database() -> Self {
+        Self::Object {
+            value: SearchFilterType::DataSource,
+            property: String::from("object"),
+            in_trash: None,
+        }
+    }
+
+    /// Restricts search results to trashed or live objects without limiting their type.
+    pub fn trash(in_trash: bool) -> Self {
+        Self::InTrash { in_trash }
+    }
+
+    /// Restricts search results to trashed or live objects.
+    pub fn in_trash(self, in_trash: bool) -> Self {
+        match self {
+            Self::Object {
+                value, property, ..
+            } => Self::Object {
+                value,
+                property,
+                in_trash: Some(in_trash),
+            },
+            Self::InTrash { .. } => Self::InTrash { in_trash },
+        }
+    }
+}
+
+impl Default for SearchFilterRequest {
+    fn default() -> Self {
+        Self::page()
+    }
+}
+
 /// <https://developers.notion.com/reference/post-search>
 /// A set of criteria that orders the search results — either by a timestamp
 /// (with a direction) or by relevance to the search query.
@@ -124,6 +191,18 @@ mod unit_tests {
         let db = SearchFilter::database();
         assert_eq!(db.value, SearchFilterType::DataSource);
 
+        let trashed_pages = SearchFilterRequest::page().in_trash(true);
+        assert_eq!(
+            serde_json::to_value(&trashed_pages).unwrap(),
+            serde_json::json!({"property": "object", "value": "page", "in_trash": true})
+        );
+
+        let live_objects = SearchFilterRequest::trash(false);
+        assert_eq!(
+            serde_json::to_value(&live_objects).unwrap(),
+            serde_json::json!({"in_trash": false})
+        );
+
         let asc = SearchSort::asc();
         match &asc {
             SearchSort::Timestamp {
@@ -152,6 +231,9 @@ mod unit_tests {
 
         let json = serde_json::to_string(&page).unwrap();
         let _: SearchFilter = serde_json::from_str(&json).unwrap();
+        let json = serde_json::to_string(&live_objects).unwrap();
+        let deserialized_live_objects: SearchFilterRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized_live_objects, live_objects);
         let json = serde_json::to_string(&asc).unwrap();
         let _: SearchSort = serde_json::from_str(&json).unwrap();
         let json = serde_json::to_string(&relevance).unwrap();
@@ -159,6 +241,7 @@ mod unit_tests {
         assert_eq!(deserialized_relevance, relevance);
 
         let _ = SearchFilter::default();
+        let _ = SearchFilterRequest::default();
         let _ = SearchSort::default();
         assert_eq!(SearchFilterType::default(), SearchFilterType::Page);
         assert_eq!(


### PR DESCRIPTION
## Summary
- add `filter_in_trash` support for general, page, and data source searches
- serialize both Notion API filter shapes without breaking the existing public `SearchFilter` type
- add unit and live read-only integration coverage for trash searches

## Verification
- `cargo test --workspace`

Closes #635