### PR TITLE
[notion-sdk-js] Sync error diagnostics with v5.23.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bytes",
  "dotenvy",

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "0.29.0"
+version = "0.30.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/notionrs/src/error/mod.rs
+++ b/notionrs/src/error/mod.rs
@@ -20,6 +20,17 @@ pub enum Error {
         status: u16,
         /// Error message
         message: String,
+        /// Notion's request identifier, taken from the error body's `request_id`
+        /// field, or from the `x-notion-request-id` response header when the body
+        /// doesn't provide one. Include it when reporting an issue to Notion.
+        request_id: Option<String>,
+        /// Value of the `cf-ray` response header, when present.
+        ///
+        /// A response carrying a Ray ID but no [`request_id`](Error::Http) was
+        /// answered at the network edge before it reached the Notion API — for
+        /// example by a network security rule. Include it when reporting an issue
+        /// to Notion.
+        ray_id: Option<String>,
     },
 
     /// This library follows the Builder pattern, allowing requests to be sent even with missing parameters.
@@ -137,30 +148,115 @@ pub struct ErrorResponse {
 }
 
 impl Error {
-    pub(crate) async fn try_from_response_async(response: reqwest::Response) -> Self {
-        let status = response.status().as_u16();
-
-        let error_body = match response.text().await{
-            Err(_) =>{
-                return crate::error::Error::Http {
-                    status,
-                    message: "An error occurred, but failed to retrieve the error details from the response body.".to_string(),
-                }},
-            Ok(body) => body
-        };
-
-        let error_json = serde_json::from_str::<crate::error::ErrorResponse>(&error_body).ok();
-
-        let error_message = match error_json {
-            Some(e) => e.message,
-            None => format!("{:?}", error_body),
-        };
-
-        crate::error::Error::Http {
-            status,
-            message: error_message,
+    /// Notion's request identifier, when this error carries one.
+    ///
+    /// Only [`Error::Http`] carries it; every other variant returns `None`.
+    pub fn request_id(&self) -> Option<&str> {
+        match self {
+            Error::Http { request_id, .. } => request_id.as_deref(),
+            _ => None,
         }
     }
+
+    /// The Cloudflare Ray ID of the response, when this error carries one.
+    ///
+    /// Only [`Error::Http`] carries it; every other variant returns `None`.
+    pub fn ray_id(&self) -> Option<&str> {
+        match self {
+            Error::Http { ray_id, .. } => ray_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    pub(crate) async fn try_from_response_async(response: reqwest::Response) -> Self {
+        let status = response.status().as_u16();
+        let headers = response.headers().clone();
+
+        let error_body = response.text().await.ok();
+
+        Self::http_from_parts(status, &headers, error_body.as_deref())
+    }
+
+    /// Builds an [`Error::Http`] from the pieces of a failed response.
+    ///
+    /// `body` is `None` when the response body could not be read.
+    fn http_from_parts(
+        status: u16,
+        headers: &reqwest::header::HeaderMap,
+        body: Option<&str>,
+    ) -> Self {
+        let ray_id = header_value(headers, "cf-ray");
+        let header_request_id = header_value(headers, "x-notion-request-id");
+
+        let Some(body) = body else {
+            return Error::Http {
+                status,
+                message: "An error occurred, but failed to retrieve the error details from the response body.".to_string(),
+                request_id: header_request_id,
+                ray_id,
+            };
+        };
+
+        match serde_json::from_str::<crate::error::ErrorResponse>(body) {
+            // A well-formed Notion API error takes precedence over any header-derived diagnostics.
+            Ok(error_response) => Error::Http {
+                status,
+                message: error_response.message,
+                request_id: error_response.request_id.or(header_request_id),
+                ray_id,
+            },
+            Err(_) => {
+                // An unrecognized response with a Ray ID but no Notion request ID was
+                // answered before it reached the Notion API. Its body is usually HTML,
+                // so surface the Ray ID instead of dumping it into the message.
+                let message = match (&ray_id, &header_request_id) {
+                    (Some(ray_id), None) => build_edge_response_message(
+                        status,
+                        header_value(headers, "content-type").as_deref(),
+                        ray_id,
+                    ),
+                    _ => format!("{:?}", body),
+                };
+
+                Error::Http {
+                    status,
+                    message,
+                    request_id: header_request_id,
+                    ray_id,
+                }
+            }
+        }
+    }
+}
+
+/// Reads a header as a `String`, ignoring values that aren't valid visible ASCII.
+///
+/// Header names are matched case-insensitively by [`reqwest::header::HeaderMap`].
+fn header_value(headers: &reqwest::header::HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+}
+
+/// Builds the message for an unrecognized response generated at the network edge.
+fn build_edge_response_message(status: u16, content_type: Option<&str>, ray_id: &str) -> String {
+    let content_type_note = match content_type {
+        Some(content_type) => format!(" (content-type: {content_type})"),
+        None => String::new(),
+    };
+
+    let blocked_request_note = if status == 403 {
+        " This may mean the request was blocked by a network security rule."
+    } else {
+        ""
+    };
+
+    format!(
+        "The response was returned by Notion's edge proxy before reaching the Notion \
+         API{content_type_note}.{blocked_request_note} Cloudflare Ray ID: {ray_id}. \
+         Include this ID when contacting Notion support."
+    )
 }
 
 // # --------------------------------------------------------------------------------
@@ -172,6 +268,199 @@ impl Error {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+
+    fn header_map(pairs: &[(&str, &str)]) -> reqwest::header::HeaderMap {
+        let mut headers = reqwest::header::HeaderMap::new();
+
+        for (name, value) in pairs {
+            headers.insert(
+                reqwest::header::HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                reqwest::header::HeaderValue::from_str(value).unwrap(),
+            );
+        }
+
+        headers
+    }
+
+    /// Unpacks an [`Error::Http`], panicking on any other variant.
+    fn unwrap_http(error: Error) -> (u16, String, Option<String>, Option<String>) {
+        match error {
+            Error::Http {
+                status,
+                message,
+                request_id,
+                ray_id,
+            } => (status, message, request_id, ray_id),
+            other => panic!("expected Error::Http, got {other:?}"),
+        }
+    }
+
+    const NOTION_ERROR_BODY: &str = r#"
+    {
+        "object": "error",
+        "status": 404,
+        "code": "object_not_found",
+        "message": "Could not find page.",
+        "request_id": "body-request-id"
+    }
+    "#;
+
+    #[test]
+    fn http_from_parts_prefers_well_formed_notion_error() {
+        let headers = header_map(&[
+            ("cf-ray", "abc123-NRT"),
+            ("x-notion-request-id", "header-request-id"),
+        ]);
+
+        let (status, message, request_id, ray_id) = unwrap_http(Error::http_from_parts(
+            404,
+            &headers,
+            Some(NOTION_ERROR_BODY),
+        ));
+
+        assert_eq!(status, 404);
+        assert_eq!(message, "Could not find page.");
+        // The body's own request_id wins over the header.
+        assert_eq!(request_id.as_deref(), Some("body-request-id"));
+        assert_eq!(ray_id.as_deref(), Some("abc123-NRT"));
+    }
+
+    #[test]
+    fn http_from_parts_falls_back_to_request_id_header() {
+        let body = r#"
+        {
+            "object": "error",
+            "status": 429,
+            "code": "rate_limited",
+            "message": "Rate limited."
+        }
+        "#;
+
+        let headers = header_map(&[("x-notion-request-id", "header-request-id")]);
+
+        let (_, message, request_id, ray_id) =
+            unwrap_http(Error::http_from_parts(429, &headers, Some(body)));
+
+        assert_eq!(message, "Rate limited.");
+        assert_eq!(request_id.as_deref(), Some("header-request-id"));
+        assert_eq!(ray_id, None);
+    }
+
+    #[test]
+    fn http_from_parts_matches_headers_case_insensitively() {
+        let headers = header_map(&[("CF-Ray", "abc123-NRT"), ("X-Notion-Request-Id", "req-1")]);
+
+        let (_, _, request_id, ray_id) = unwrap_http(Error::http_from_parts(
+            404,
+            &headers,
+            Some(r#"{"not":"a notion error"}"#),
+        ));
+
+        assert_eq!(request_id.as_deref(), Some("req-1"));
+        assert_eq!(ray_id.as_deref(), Some("abc123-NRT"));
+    }
+
+    #[test]
+    fn http_from_parts_diagnoses_edge_generated_403() {
+        let headers = header_map(&[("cf-ray", "abc123-NRT"), ("content-type", "text/html")]);
+
+        let (status, message, request_id, ray_id) = unwrap_http(Error::http_from_parts(
+            403,
+            &headers,
+            Some("<html><body>Blocked</body></html>"),
+        ));
+
+        assert_eq!(status, 403);
+        assert_eq!(
+            message,
+            "The response was returned by Notion's edge proxy before reaching the Notion API \
+             (content-type: text/html). This may mean the request was blocked by a network \
+             security rule. Cloudflare Ray ID: abc123-NRT. Include this ID when contacting \
+             Notion support."
+        );
+        // The HTML body is kept out of the message.
+        assert!(!message.contains("<html>"));
+        assert_eq!(request_id, None);
+        assert_eq!(ray_id.as_deref(), Some("abc123-NRT"));
+        assert_eq!(
+            Error::http_from_parts(403, &headers, Some("<html></html>")).to_string(),
+            format!("HTTP error 403: {message}")
+        );
+    }
+
+    #[test]
+    fn http_from_parts_diagnoses_edge_generated_non_403_without_content_type() {
+        let headers = header_map(&[("cf-ray", "def456-NRT")]);
+
+        let (_, message, _, _) =
+            unwrap_http(Error::http_from_parts(502, &headers, Some("Bad Gateway")));
+
+        assert_eq!(
+            message,
+            "The response was returned by Notion's edge proxy before reaching the Notion API. \
+             Cloudflare Ray ID: def456-NRT. Include this ID when contacting Notion support."
+        );
+        assert!(!message.contains("content-type"));
+        assert!(!message.contains("network security rule"));
+    }
+
+    #[test]
+    fn http_from_parts_keeps_raw_body_when_notion_answered() {
+        // A Ray ID together with a Notion request ID means the response did reach the
+        // API, so the body is still the best available diagnostic.
+        let headers = header_map(&[("cf-ray", "abc123-NRT"), ("x-notion-request-id", "req-1")]);
+
+        let (_, message, request_id, ray_id) =
+            unwrap_http(Error::http_from_parts(500, &headers, Some("not json")));
+
+        assert_eq!(message, "\"not json\"");
+        assert_eq!(request_id.as_deref(), Some("req-1"));
+        assert_eq!(ray_id.as_deref(), Some("abc123-NRT"));
+    }
+
+    #[test]
+    fn http_from_parts_keeps_raw_body_without_ray_id() {
+        let (_, message, request_id, ray_id) = unwrap_http(Error::http_from_parts(
+            500,
+            &reqwest::header::HeaderMap::new(),
+            Some("not json"),
+        ));
+
+        assert_eq!(message, "\"not json\"");
+        assert_eq!(request_id, None);
+        assert_eq!(ray_id, None);
+    }
+
+    #[test]
+    fn http_from_parts_without_readable_body() {
+        let headers = header_map(&[("cf-ray", "abc123-NRT")]);
+
+        let (status, message, request_id, ray_id) =
+            unwrap_http(Error::http_from_parts(500, &headers, None));
+
+        assert_eq!(status, 500);
+        assert_eq!(
+            message,
+            "An error occurred, but failed to retrieve the error details from the response body."
+        );
+        assert_eq!(request_id, None);
+        assert_eq!(ray_id.as_deref(), Some("abc123-NRT"));
+    }
+
+    #[test]
+    fn request_id_and_ray_id_accessors() {
+        let error = Error::http_from_parts(
+            403,
+            &header_map(&[("cf-ray", "abc123-NRT"), ("x-notion-request-id", "req-1")]),
+            Some("nope"),
+        );
+        assert_eq!(error.request_id(), Some("req-1"));
+        assert_eq!(error.ray_id(), Some("abc123-NRT"));
+
+        let error = Error::Network("connection reset".to_string());
+        assert_eq!(error.request_id(), None);
+        assert_eq!(error.ray_id(), None);
+    }
 
     #[test]
     fn unexpected_async_task_display() {

--- a/notionrs/tests/readonly/async_task.rs
+++ b/notionrs/tests/readonly/async_task.rs
@@ -24,7 +24,23 @@ mod integration_tests {
 
         assert!(result.is_err());
 
-        match result.unwrap_err() {
+        let error = result.unwrap_err();
+
+        // A real Notion API error always carries a request_id in its body.
+        assert!(
+            error.request_id().is_some_and(|id| !id.is_empty()),
+            "expected a request_id, got: {:?}",
+            error.request_id()
+        );
+
+        // Notion currently serves the API from behind Cloudflare, so a `cf-ray`
+        // header is expected — but don't fail the suite if that ever changes.
+        assert!(
+            error.ray_id().is_none_or(|id| !id.is_empty()),
+            "ray_id was present but empty"
+        );
+
+        match error {
             notionrs::Error::Http { status, .. } => {
                 assert!((400..500).contains(&status), "unexpected status: {status}");
             }


### PR DESCRIPTION
## Overview

Syncs `notionrs` with [`notion-sdk-js` v5.23.3](https://github.com/makenotion/notion-sdk-js/releases/tag/v5.23.3).

That release contains **no schema or API surface changes** — it's a reliability fix that makes edge-proxy-blocked requests diagnosable. When a request is rejected at the network edge (for example by a network security rule), the response is HTML rather than a Notion error body. `notionrs` previously handled this the worst possible way: it dumped the debug-quoted HTML into the error message and discarded `request_id` entirely, so there was nothing actionable to report to Notion support.

## Related Issues

- Closes #654

## Changes

- **`Error::Http` now carries response diagnostics.** Two new fields:
  - `request_id: Option<String>` — from the error body's `request_id`, falling back to the `x-notion-request-id` response header when the body doesn't provide one (previously the body's `request_id` was parsed and then thrown away).
  - `ray_id: Option<String>` — from the `cf-ray` response header.
- **Added `Error::request_id()` / `Error::ray_id()` accessors**, so callers can read the diagnostics without matching on the variant. Both return `None` for every other variant.
- **Unrecognized responses are now diagnosed.** A response with a Ray ID but *no* Notion request ID was answered before it reached the API, so its message now says so — including the `content-type` and, for 403s, that a network security rule may be responsible — instead of embedding the HTML body. Well-formed Notion API errors take precedence and keep their own message; unparseable bodies that Notion itself answered (Ray ID *and* request ID present, or no Ray ID at all) still fall back to the raw body as before.
- **Refactor for testability:** the response-handling logic moved into `Error::http_from_parts(status, headers, body)`, with `try_from_response_async` reduced to reading the parts off the `reqwest::Response`. This makes the whole matrix unit-testable without HTTP plumbing or an added `http` dev-dependency.

### Not applicable from this release

The upstream `retry-after` header fix (case-insensitive lookup, array-valued headers) has no counterpart here: `notionrs` implements no retry logic at all, and `reqwest::header::HeaderMap` already normalizes header names, so lookups are case-insensitive by construction.

### ⚠️ Breaking change

`Error::Http` gained two fields, so exhaustive struct patterns like `Error::Http { status, message }` need updating (`..` patterns are unaffected). The only in-repo call site already used `..`. Per `AGENTS.md`, releases bump the minor version regardless of breaking changes.

## Testing

- **9 new unit tests** covering the full matrix: body-vs-header `request_id` precedence, header fallback, case-insensitive header matching, the edge-proxy message for 403 (with `content-type` and the security-rule note) and non-403 (without either), raw-body fallback both when Notion answered and when no Ray ID is present, an unreadable body, and the accessors. Full `Display` output is asserted, along with the HTML body *not* leaking into the message.
- **102 readonly + 46 mutable integration tests pass** against a live Notion workspace, plus all 56 unit tests.
- `readonly/async_task.rs` was extended to assert the diagnostics are populated on a real Notion error. This confirmed the header path works end-to-end against the live API — the 404 came back with `request_id: Some("b554e608-…")` and `ray_id: Some("a234110d2e2ff4a6-NRT")`, i.e. Notion really does serve a `cf-ray` header. The `ray_id` assertion is deliberately written as "if present, non-empty" so the suite doesn't break if Notion ever moves off Cloudflare; `request_id` is asserted strictly since it's a documented part of every error body.

## Checklist

- [x] The target branch for this PR is `main`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] If you added new structs to `notionrs_types`, ensure you re-export the structs in the `prelude` module. — N/A, no new structs; the change is confined to `notionrs`.
- [x] Documentation has been updated if necessary. — new fields and accessors are documented (the module is `#![deny(missing_docs)]`). No README change: no endpoint was added or removed.
- [ ] Release tags have been added if needed.

## Additional Notes

- `cargo clippy` still cannot run to completion — it fails on `notionrs_types/src/object/file_upload.rs` due to the non-semver `since` in a `#[deprecated(...)]`, the pre-existing issue #629 already documented in `AGENTS.md`. Verified via `cargo check --workspace --tests --examples` and the test suites instead. No files touched by this PR are implicated.
- Only the two files actually changed were formatted, per the `AGENTS.md` note about pre-existing repo-wide `cargo fmt` drift.
- Nothing new was found worth filing as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
