### PR TITLE
[notion-sdk-js] Sync schema with v5.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "bytes",
  "dotenvy",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "notionrs_types"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "notionrs_macro",
  "serde",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ As part of the alpha release, the following features are available. Please note 
   - [Retrieve block children](https://developers.notion.com/reference/get-block-children)
   - [Update a block](https://developers.notion.com/reference/update-a-block)
   - [Delete a block](https://developers.notion.com/reference/delete-a-block)
+  - [Create a meeting note](https://developers.notion.com/reference/create-meeting-note)
 - Databases
   - [Create a database](https://developers.notion.com/reference/create-a-database)
   - [Update a database](https://developers.notion.com/reference/update-a-database)

--- a/notionrs/Cargo.toml
+++ b/notionrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs"
 description = "A Notion API client that provides type-safe request serialization and response deserialization"
-version = "0.30.0"
+version = "0.31.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }
@@ -15,7 +15,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-notionrs_types = { version = "0.22.0", path = "../notionrs_types" }
+notionrs_types = { version = "0.23.0", path = "../notionrs_types" }
 notionrs_macro = { version = "0.4.0", path = "../notionrs_macro" }
 
 reqwest = { workspace = true }

--- a/notionrs/src/client/block/create_meeting_note.rs
+++ b/notionrs/src/client/block/create_meeting_note.rs
@@ -1,0 +1,201 @@
+use notionrs_types::object::request::meeting_notes::{
+    CreateMeetingNoteLanguage, CreateMeetingNoteSource,
+};
+use serde::Serialize;
+
+/// Client for the create meeting note endpoint.
+///
+/// A file upload source requires `parent_page_id`. An existing block source
+/// must omit it.
+///
+/// <https://developers.notion.com/reference/create-meeting-note>
+#[derive(Debug, Default, notionrs_macro::Setter)]
+pub struct CreateMeetingNoteClient {
+    /// The reqwest HTTP client.
+    pub(crate) reqwest_client: reqwest::Client,
+
+    pub(crate) source: Option<CreateMeetingNoteSource>,
+
+    pub(crate) parent_page_id: Option<String>,
+
+    pub(crate) title: Option<String>,
+
+    pub(crate) language: Option<CreateMeetingNoteLanguage>,
+
+    pub(crate) kickoff_summary: Option<bool>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct CreateMeetingNoteRequestBody {
+    source: CreateMeetingNoteSource,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent: Option<CreateMeetingNoteParent>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language: Option<CreateMeetingNoteLanguage>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    options: Option<CreateMeetingNoteOptions>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CreateMeetingNoteParent {
+    r#type: &'static str,
+    page_id: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CreateMeetingNoteOptions {
+    kickoff_summary: bool,
+}
+
+impl CreateMeetingNoteClient {
+    /// Use a completed public API file upload as the source.
+    pub fn file_upload_source(mut self, file_upload_id: impl AsRef<str>) -> Self {
+        self.source = Some(CreateMeetingNoteSource::file_upload(file_upload_id));
+        self
+    }
+
+    /// Use an existing audio, video, or file block as the source.
+    pub fn block_source(mut self, block_id: impl AsRef<str>) -> Self {
+        self.source = Some(CreateMeetingNoteSource::block(block_id));
+        self
+    }
+
+    fn into_request_body(self) -> Result<CreateMeetingNoteRequestBody, crate::error::Error> {
+        let source = self.source.ok_or(crate::error::Error::RequestParameter(
+            "`source` is not set.".to_owned(),
+        ))?;
+
+        let parent = match (&source, self.parent_page_id) {
+            (CreateMeetingNoteSource::FileUpload { .. }, Some(page_id)) => {
+                Some(CreateMeetingNoteParent {
+                    r#type: "page_id",
+                    page_id,
+                })
+            }
+            (CreateMeetingNoteSource::FileUpload { .. }, None) => {
+                return Err(crate::error::Error::RequestParameter(
+                    "`parent_page_id` is required for a file upload source.".to_owned(),
+                ));
+            }
+            (CreateMeetingNoteSource::Block { .. }, Some(_)) => {
+                return Err(crate::error::Error::RequestParameter(
+                    "`parent_page_id` must not be set for a block source.".to_owned(),
+                ));
+            }
+            (CreateMeetingNoteSource::Block { .. }, None) => None,
+        };
+
+        Ok(CreateMeetingNoteRequestBody {
+            source,
+            parent,
+            title: self.title,
+            language: self.language,
+            options: self
+                .kickoff_summary
+                .map(|kickoff_summary| CreateMeetingNoteOptions { kickoff_summary }),
+        })
+    }
+
+    /// Create a meeting note and begin processing its source media.
+    ///
+    /// <https://developers.notion.com/reference/create-meeting-note>
+    pub async fn send(
+        self,
+    ) -> Result<notionrs_types::object::block::CreateMeetingNoteResponse, crate::error::Error> {
+        let reqwest_client = self.reqwest_client.clone();
+        let request_body = serde_json::to_string(&self.into_request_body()?)?;
+        let request = reqwest_client
+            .post("https://api.notion.com/v1/blocks/meeting_notes")
+            .header("Content-Type", "application/json")
+            .body(request_body);
+
+        crate::util::send_and_convert(request).await
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    fn request_error(client: CreateMeetingNoteClient) -> String {
+        match client.into_request_body().unwrap_err() {
+            crate::error::Error::RequestParameter(message) => message,
+            error => panic!("expected request parameter error, got {error:?}"),
+        }
+    }
+
+    #[test]
+    fn serialize_file_upload_request() {
+        let body = CreateMeetingNoteClient::default()
+            .file_upload_source("upload-id")
+            .parent_page_id("page-id")
+            .title("Weekly sync")
+            .language(CreateMeetingNoteLanguage::English)
+            .kickoff_summary(true)
+            .into_request_body()
+            .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(body).unwrap(),
+            serde_json::json!({
+                "source": {
+                    "type": "file_upload",
+                    "file_upload_id": "upload-id"
+                },
+                "parent": {
+                    "type": "page_id",
+                    "page_id": "page-id"
+                },
+                "title": "Weekly sync",
+                "language": "en",
+                "options": {
+                    "kickoff_summary": true
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn serialize_block_request_without_parent() {
+        let body = CreateMeetingNoteClient::default()
+            .block_source("block-id")
+            .into_request_body()
+            .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(body).unwrap(),
+            serde_json::json!({
+                "source": {
+                    "type": "block",
+                    "block_id": "block-id"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn validate_source_and_parent_requirements() {
+        assert_eq!(
+            request_error(CreateMeetingNoteClient::default()),
+            "`source` is not set."
+        );
+        assert_eq!(
+            request_error(CreateMeetingNoteClient::default().file_upload_source("upload-id")),
+            "`parent_page_id` is required for a file upload source."
+        );
+        assert_eq!(
+            request_error(
+                CreateMeetingNoteClient::default()
+                    .block_source("block-id")
+                    .parent_page_id("page-id")
+            ),
+            "`parent_page_id` must not be set for a block source."
+        );
+    }
+}

--- a/notionrs/src/client/block/mod.rs
+++ b/notionrs/src/client/block/mod.rs
@@ -1,4 +1,5 @@
 pub mod append_block_children;
+pub mod create_meeting_note;
 pub mod delete_block;
 pub mod get_block;
 pub mod get_block_children;

--- a/notionrs/src/client/file_upload/send_file_upload.rs
+++ b/notionrs/src/client/file_upload/send_file_upload.rs
@@ -9,6 +9,27 @@ pub struct SendFileUploadClient {
     pub(crate) part_number: Option<u32>,
 
     pub(crate) filename: Option<String>,
+
+    /// MIME type of the multipart file part.
+    pub(crate) content_type: Option<String>,
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn reject_invalid_content_type_before_sending() {
+        let error = SendFileUploadClient::default()
+            .file_upload_id("upload-id")
+            .file(vec![0])
+            .content_type("not a MIME type")
+            .send()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, crate::error::Error::RequestParameter(_)));
+    }
 }
 
 impl SendFileUploadClient {
@@ -23,19 +44,21 @@ impl SendFileUploadClient {
             "`file` is not set.".to_owned(),
         ))?;
 
+        let mut file_part = reqwest::multipart::Part::bytes(file)
+            .file_name(self.filename.unwrap_or("untitled".to_owned()));
+        if let Some(content_type) = self.content_type {
+            file_part = file_part.mime_str(&content_type).map_err(|error| {
+                crate::error::Error::RequestParameter(format!(
+                    "`content_type` is not a valid MIME type: {error}"
+                ))
+            })?;
+        }
+
         let form = match self.part_number {
             Some(part_number) => reqwest::multipart::Form::new()
-                .part(
-                    "file",
-                    reqwest::multipart::Part::bytes(file)
-                        .file_name(self.filename.unwrap_or("untitled".to_owned())),
-                )
+                .part("file", file_part)
                 .text("part_number", part_number.to_string()),
-            None => reqwest::multipart::Form::new().part(
-                "file",
-                reqwest::multipart::Part::bytes(file)
-                    .file_name(self.filename.unwrap_or("untitled".to_owned())),
-            ),
+            None => reqwest::multipart::Form::new().part("file", file_part),
         };
 
         let request = self

--- a/notionrs/src/client/mod.rs
+++ b/notionrs/src/client/mod.rs
@@ -328,6 +328,18 @@ impl Client {
         }
     }
 
+    /// Create a meeting note from uploaded media or an existing media block.
+    ///
+    /// <https://developers.notion.com/reference/create-meeting-note>
+    pub fn create_meeting_note(
+        &self,
+    ) -> crate::client::block::create_meeting_note::CreateMeetingNoteClient {
+        crate::client::block::create_meeting_note::CreateMeetingNoteClient {
+            reqwest_client: self.reqwest_client.clone(),
+            ..Default::default()
+        }
+    }
+
     /// Query meeting notes.
     ///
     /// <https://developers.notion.com/reference/query-meeting-notes>

--- a/notionrs/src/error/mod.rs
+++ b/notionrs/src/error/mod.rs
@@ -75,6 +75,8 @@ pub enum ApiErrorCode {
     InvalidRequest,
     /// The request is missing the `Notion-Version` header.
     MissingVersion,
+    /// The `Notion-Beta` header is invalid or missing when required.
+    InvalidBeta,
     /// The bearer token is not valid.
     Unauthorized,
     /// Given the bearer token used, the client doesn't have permission to perform this operation.
@@ -109,6 +111,7 @@ impl std::fmt::Display for ApiErrorCode {
             ApiErrorCode::InvalidRequestUrl => write!(f, "invalid_request_url"),
             ApiErrorCode::InvalidRequest => write!(f, "invalid_request"),
             ApiErrorCode::MissingVersion => write!(f, "missing_version"),
+            ApiErrorCode::InvalidBeta => write!(f, "invalid_beta"),
             ApiErrorCode::Unauthorized => write!(f, "unauthorized"),
             ApiErrorCode::RestrictedResource => write!(f, "restricted_resource"),
             ApiErrorCode::ValidationError => write!(f, "validation_error"),
@@ -487,6 +490,7 @@ mod unit_tests {
             (r#""invalid_request_url""#, ApiErrorCode::InvalidRequestUrl),
             (r#""invalid_request""#, ApiErrorCode::InvalidRequest),
             (r#""missing_version""#, ApiErrorCode::MissingVersion),
+            (r#""invalid_beta""#, ApiErrorCode::InvalidBeta),
             (r#""unauthorized""#, ApiErrorCode::Unauthorized),
             (r#""restricted_resource""#, ApiErrorCode::RestrictedResource),
             (r#""validation_error""#, ApiErrorCode::ValidationError),
@@ -559,6 +563,7 @@ mod unit_tests {
             "row_limit_exceeded"
         );
         assert_eq!(ApiErrorCode::MissingVersion.to_string(), "missing_version");
+        assert_eq!(ApiErrorCode::InvalidBeta.to_string(), "invalid_beta");
         assert_eq!(
             ApiErrorCode::Unknown("custom".to_string()).to_string(),
             "custom"

--- a/notionrs/tests/mutable/block/create_meeting_note.rs
+++ b/notionrs/tests/mutable/block/create_meeting_note.rs
@@ -1,0 +1,72 @@
+mod integration_tests {
+    use notionrs::client::file_upload::create_file_upload::FileUploadMode;
+    use notionrs_types::prelude::CreateMeetingNoteLanguage;
+
+    /// <https://www.notion.so/33da03d79b26803694f1fd9a8d867184>
+    static PAGE_ID: &str = "33da03d79b26803694f1fd9a8d867184";
+
+    fn silent_wav() -> Vec<u8> {
+        const SAMPLE_RATE: u32 = 8_000;
+        const SECONDS: u32 = 10;
+        const BITS_PER_SAMPLE: u16 = 16;
+        const CHANNELS: u16 = 1;
+
+        let data_size = SAMPLE_RATE * SECONDS * u32::from(BITS_PER_SAMPLE / 8);
+        let mut wav = Vec::with_capacity(44 + data_size as usize);
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&(36 + data_size).to_le_bytes());
+        wav.extend_from_slice(b"WAVEfmt ");
+        wav.extend_from_slice(&16u32.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes());
+        wav.extend_from_slice(&CHANNELS.to_le_bytes());
+        wav.extend_from_slice(&SAMPLE_RATE.to_le_bytes());
+        wav.extend_from_slice(&(SAMPLE_RATE * u32::from(BITS_PER_SAMPLE / 8)).to_le_bytes());
+        wav.extend_from_slice(&(CHANNELS * (BITS_PER_SAMPLE / 8)).to_le_bytes());
+        wav.extend_from_slice(&BITS_PER_SAMPLE.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&data_size.to_le_bytes());
+        wav.resize(44 + data_size as usize, 0);
+        wav
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a Notion plan with AI meeting notes enabled"]
+    async fn create_meeting_note_from_file_upload() -> Result<(), notionrs::Error> {
+        dotenvy::dotenv().ok();
+
+        let notion_api_key = std::env::var("NOTION_API_KEY_MUTABLE").unwrap();
+        let client = notionrs::Client::new(notion_api_key);
+
+        let file_upload = client
+            .create_file_upload()
+            .mode(FileUploadMode::SinglePart)
+            .filename("meeting-note-test.wav")
+            .content_type("audio/wav")
+            .send()
+            .await?;
+        let file_upload = client
+            .send_file_upload()
+            .file_upload_id(file_upload.id)
+            .file(silent_wav())
+            .filename("meeting-note-test.wav")
+            .content_type("audio/wav")
+            .send()
+            .await?;
+
+        let response = client
+            .create_meeting_note()
+            .file_upload_source(file_upload.id)
+            .parent_page_id(PAGE_ID)
+            .title("notionrs integration test")
+            .language(CreateMeetingNoteLanguage::English)
+            .kickoff_summary(false)
+            .send()
+            .await?;
+        let block_id = response.id().to_owned();
+
+        client.delete_block().block_id(&block_id).send().await?;
+
+        assert!(!block_id.is_empty());
+        Ok(())
+    }
+}

--- a/notionrs/tests/mutable/block/mod.rs
+++ b/notionrs/tests/mutable/block/mod.rs
@@ -1,4 +1,5 @@
 mod append_block_children_position;
+mod create_meeting_note;
 mod crud_audio_block;
 mod crud_bookmark_block;
 mod crud_breadcrumb_block;

--- a/notionrs/tests/mutable/file_upload/upload_file.rs
+++ b/notionrs/tests/mutable/file_upload/upload_file.rs
@@ -25,6 +25,8 @@ mod integration_tests {
             .send_file_upload()
             .file_upload_id(id)
             .file(file.to_vec())
+            .filename("notionrs-test.txt")
+            .content_type("text/plain")
             .send()
             .await?
             .id;

--- a/notionrs/tests/readonly/data_source/query_data_source.rs
+++ b/notionrs/tests/readonly/data_source/query_data_source.rs
@@ -217,11 +217,11 @@ mod integration_tests {
         let filter = notionrs_types::object::request::filter::Filter::or(vec![
             notionrs_types::object::request::filter::Filter::multi_select_contains(
                 "Multi-select",
-                "0",
+                "Something",
             ),
             notionrs_types::object::request::filter::Filter::multi_select_does_not_contain(
                 "Multi-select",
-                "0",
+                "Something",
             ),
             notionrs_types::object::request::filter::Filter::multi_select_is_empty("Multi-select"),
             notionrs_types::object::request::filter::Filter::multi_select_is_not_empty(

--- a/notionrs/tests/readonly/data_source/query_data_source_all.rs
+++ b/notionrs/tests/readonly/data_source/query_data_source_all.rs
@@ -232,11 +232,11 @@ mod integration_tests {
         let filter = notionrs_types::object::request::filter::Filter::or(vec![
             notionrs_types::object::request::filter::Filter::multi_select_contains(
                 "Multi-select",
-                "0",
+                "Something",
             ),
             notionrs_types::object::request::filter::Filter::multi_select_does_not_contain(
                 "Multi-select",
-                "0",
+                "Something",
             ),
             notionrs_types::object::request::filter::Filter::multi_select_is_empty("Multi-select"),
             notionrs_types::object::request::filter::Filter::multi_select_is_not_empty(

--- a/notionrs/tests/readonly/data_source/query_data_source_all_with_struct.rs
+++ b/notionrs/tests/readonly/data_source/query_data_source_all_with_struct.rs
@@ -231,11 +231,11 @@ mod integration_tests {
         let filter = notionrs_types::object::request::filter::Filter::or(vec![
             notionrs_types::object::request::filter::Filter::multi_select_contains(
                 "Multi-select",
-                "0",
+                "Something",
             ),
             notionrs_types::object::request::filter::Filter::multi_select_does_not_contain(
                 "Multi-select",
-                "0",
+                "Something",
             ),
             notionrs_types::object::request::filter::Filter::multi_select_is_empty("Multi-select"),
             notionrs_types::object::request::filter::Filter::multi_select_is_not_empty(

--- a/notionrs_types/Cargo.toml
+++ b/notionrs_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notionrs_types"
 description = "Shared schema definitions for the Notion API used by the notionrs ecosystem."
-version = "0.22.0"
+version = "0.23.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/notionrs_types/src/object/async_task.rs
+++ b/notionrs_types/src/object/async_task.rs
@@ -148,6 +148,8 @@ pub enum AsyncTaskErrorCode {
     InvalidRequest,
     /// The request is missing the `Notion-Version` header.
     MissingVersion,
+    /// The `Notion-Beta` header is invalid or missing when required.
+    InvalidBeta,
     /// The body of the request is not valid.
     ValidationError,
     /// The bearer token is not valid.
@@ -296,6 +298,39 @@ mod unit_tests {
             AsyncTaskResponse::Failed(failed) => {
                 assert_eq!(failed.error.code, AsyncTaskErrorCode::ServiceOverload);
                 assert_eq!(failed.error.message, "Notion is overloaded.");
+            }
+            _ => panic!("Expected Failed variant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_async_task_failed_with_invalid_beta() {
+        let json = r#"
+        {
+            "object": "async_task",
+            "id": "task-id-123",
+            "status": "failed",
+            "status_url": "https://api.notion.com/v1/async_tasks/task-id-123",
+            "created_time": "2026-08-05T00:00:00.000Z",
+            "operation": { "surface": "rest", "name": "create_page" },
+            "error": {
+                "object": "error",
+                "status": 400,
+                "code": "invalid_beta",
+                "message": "The beta revision is no longer supported.",
+                "additional_data": { "beta": "notion-as-code" }
+            }
+        }
+        "#;
+
+        let task: AsyncTaskResponse = serde_json::from_str(json).expect("Failed to deserialize");
+        match task {
+            AsyncTaskResponse::Failed(failed) => {
+                assert_eq!(failed.error.code, AsyncTaskErrorCode::InvalidBeta);
+                assert_eq!(
+                    failed.error.message,
+                    "The beta revision is no longer supported."
+                );
             }
             _ => panic!("Expected Failed variant"),
         }

--- a/notionrs_types/src/object/block/mod.rs
+++ b/notionrs_types/src/object/block/mod.rs
@@ -100,6 +100,9 @@ pub struct MeetingNotesBlockResponse {
 
     pub id: String,
 
+    /// Always `"meeting_notes"`.
+    pub r#type: String,
+
     /// ISO 8601 timestamp when this meeting note was created.
     #[serde(with = "time::serde::rfc3339")]
     pub created_time: time::OffsetDateTime,
@@ -121,6 +124,41 @@ pub struct MeetingNotesBlockResponse {
     pub in_trash: bool,
 
     pub meeting_notes: transcription::TranscriptionBlock,
+}
+
+/// ID-only meeting note response returned without the Read content capability.
+///
+/// <https://developers.notion.com/reference/create-meeting-note>
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct PartialMeetingNotesBlockResponse {
+    /// Always `"block"`.
+    pub object: String,
+
+    /// ID of the created meeting notes block.
+    pub id: String,
+}
+
+/// Response from the create meeting note endpoint.
+///
+/// <https://developers.notion.com/reference/create-meeting-note>
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum CreateMeetingNoteResponse {
+    /// Full block data returned with the Read content capability.
+    Full(MeetingNotesBlockResponse),
+    /// ID-only data returned without the Read content capability.
+    Partial(PartialMeetingNotesBlockResponse),
+}
+
+impl CreateMeetingNoteResponse {
+    /// Return the ID of the created meeting notes block.
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Full(response) => &response.id,
+            Self::Partial(response) => &response.id,
+        }
+    }
 }
 
 /// Response from the query meeting notes endpoint.
@@ -599,6 +637,63 @@ mod unit_tests {
             }
             _ => panic!("Expected Heading4 block"),
         }
+    }
+
+    #[test]
+    fn deserialize_create_meeting_note_responses() {
+        let partial: CreateMeetingNoteResponse = serde_json::from_value(serde_json::json!({
+            "object": "block",
+            "id": "partial-block-id"
+        }))
+        .unwrap();
+        assert!(matches!(partial, CreateMeetingNoteResponse::Partial(_)));
+        assert_eq!(partial.id(), "partial-block-id");
+
+        let full: CreateMeetingNoteResponse = serde_json::from_value(serde_json::json!({
+            "object": "block",
+            "id": "full-block-id",
+            "type": "meeting_notes",
+            "meeting_notes": {
+                "status": "transcription_failed"
+            },
+            "created_time": "2026-08-05T19:00:00.000Z",
+            "last_edited_time": "2026-08-05T19:00:00.000Z",
+            "created_by": {
+                "object": "user",
+                "id": "user-id"
+            },
+            "last_edited_by": {
+                "object": "user",
+                "id": "user-id"
+            },
+            "has_children": false,
+            "in_trash": false
+        }))
+        .unwrap();
+        assert!(matches!(full, CreateMeetingNoteResponse::Full(_)));
+        assert_eq!(full.id(), "full-block-id");
+
+        let malformed_full = serde_json::json!({
+            "object": "block",
+            "id": "full-block-id",
+            "type": "meeting_notes",
+            "meeting_notes": {
+                "status": "future_status"
+            },
+            "created_time": "2026-08-05T19:00:00.000Z",
+            "last_edited_time": "2026-08-05T19:00:00.000Z",
+            "created_by": {
+                "object": "user",
+                "id": "user-id"
+            },
+            "last_edited_by": {
+                "object": "user",
+                "id": "user-id"
+            },
+            "has_children": false,
+            "in_trash": false
+        });
+        assert!(serde_json::from_value::<CreateMeetingNoteResponse>(malformed_full).is_err());
     }
 
     #[test]

--- a/notionrs_types/src/object/block/transcription.rs
+++ b/notionrs_types/src/object/block/transcription.rs
@@ -30,6 +30,7 @@ pub enum TranscriptionStatus {
     TranscriptionNotStarted,
     TranscriptionPaused,
     TranscriptionInProgress,
+    TranscriptionFailed,
     SummaryInProgress,
     NotesReady,
 }

--- a/notionrs_types/src/object/page/formula.rs
+++ b/notionrs_types/src/object/page/formula.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 ///   - `date`
 ///   - `number`
 ///   - `string`
+///   - `unsupported`
 ///
 /// **Note**: The `['*']` part represents the column name you set when creating the database.
 ///
@@ -53,6 +54,7 @@ pub enum Formula {
     Date(FormulaDate),
     Number(FormulaNumber),
     String(FormulaString),
+    Unsupported(FormulaUnsupported),
 }
 
 impl std::fmt::Display for Formula {
@@ -62,6 +64,7 @@ impl std::fmt::Display for Formula {
             Formula::Date(d) => write!(f, "{}", d.date.unwrap_or_default()),
             Formula::Number(n) => write!(f, "{}", n.number.unwrap_or(0.0)),
             Formula::String(s) => write!(f, "{}", s.string.as_deref().unwrap_or("")),
+            Formula::Unsupported(_) => write!(f, ""),
         }
     }
 }
@@ -114,6 +117,19 @@ pub struct FormulaString {
     pub string: Option<String>,
 }
 
+/// A formula value that Notion did not compute.
+///
+/// ```json
+/// {
+///   "type": "unsupported",
+///   "unsupported": {}
+/// }
+/// ```
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct FormulaUnsupported {
+    pub unsupported: std::collections::HashMap<(), ()>,
+}
+
 // # --------------------------------------------------------------------------------
 //
 // unit test
@@ -154,6 +170,7 @@ mod unit_tests {
             Formula::Boolean(_) => panic!(),
             Formula::Date(_) => panic!(),
             Formula::Number(_) => panic!(),
+            Formula::Unsupported(_) => panic!(),
         }
     }
 
@@ -187,5 +204,23 @@ mod unit_tests {
         let _ = date.to_string();
         let date_none = Formula::Date(FormulaDate { date: None });
         let _ = date_none.to_string();
+        let unsupported = Formula::Unsupported(FormulaUnsupported {
+            unsupported: std::collections::HashMap::new(),
+        });
+        assert_eq!(unsupported.to_string(), "");
+    }
+
+    #[test]
+    fn deserialize_unsupported_formula() {
+        let property: PageFormulaProperty = serde_json::from_value(serde_json::json!({
+            "id": "formula-id",
+            "formula": {
+                "type": "unsupported",
+                "unsupported": {}
+            }
+        }))
+        .unwrap();
+
+        assert!(matches!(property.formula, Formula::Unsupported(_)));
     }
 }

--- a/notionrs_types/src/object/page/mod.rs
+++ b/notionrs_types/src/object/page/mod.rs
@@ -245,7 +245,7 @@ mod tests {
             place::PagePlaceProperty,
             relation::PageRelationProperty,
             rich_text::PageRichTextProperty,
-            rollup::PageRollupProperty,
+            rollup::{PageRollupProperty, Rollup, RollupNumber},
             select::PageSelectProperty,
             status::PageStatusProperty,
             title::PageTitleProperty,
@@ -286,7 +286,13 @@ mod tests {
             PageProperty::Place(PagePlaceProperty::default()),
             PageProperty::Relation(PageRelationProperty::default()),
             PageProperty::RichText(PageRichTextProperty::from("text")),
-            PageProperty::Rollup(PageRollupProperty { id: None }),
+            PageProperty::Rollup(PageRollupProperty {
+                id: None,
+                rollup: Rollup::Number(RollupNumber {
+                    number: Some(1.0),
+                    function: crate::object::data_source::rollup::RollupFunction::Sum,
+                }),
+            }),
             PageProperty::Select(PageSelectProperty::default()),
             PageProperty::Status(PageStatusProperty::default().status(Select::from("S"))),
             PageProperty::Title(PageTitleProperty::from("Title")),

--- a/notionrs_types/src/object/page/rollup.rs
+++ b/notionrs_types/src/object/page/rollup.rs
@@ -1,35 +1,164 @@
 use serde::{Deserialize, Serialize};
 
-// TODO: Implement the Rollup object.
+use crate::object::data_source::rollup::RollupFunction;
+
+/// A calculated rollup page property value.
+///
+/// <https://developers.notion.com/reference/page-property-values#rollup>
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PageRollupProperty {
     /// An underlying identifier for the property.
     /// `id` remains constant when the property name changes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+
+    /// The result of evaluating the rollup.
+    pub rollup: Rollup,
 }
 
 impl std::fmt::Display for PageRollupProperty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "")
+        write!(f, "{}", self.rollup)
     }
 }
 
-// # --------------------------------------------------------------------------------
-//
-// unit test
-//
-// # --------------------------------------------------------------------------------
+/// The calculated value of a rollup property.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Rollup {
+    Number(RollupNumber),
+    Date(RollupDate),
+    Array(RollupArray),
+    Unsupported(RollupUnsupported),
+    Incomplete(RollupIncomplete),
+}
+
+impl std::fmt::Display for Rollup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Number(value) => write!(f, "{}", value.number.unwrap_or(0.0)),
+            Self::Date(value) => match &value.date {
+                Some(date) => write!(f, "{date}"),
+                None => write!(f, ""),
+            },
+            Self::Array(value) => {
+                for item in &value.array {
+                    if let RollupArrayItem::Property(property) = item {
+                        write!(f, "{property}")?;
+                    }
+                }
+                Ok(())
+            }
+            Self::Unsupported(_) | Self::Incomplete(_) => write!(f, ""),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RollupNumber {
+    pub number: Option<f64>,
+    pub function: RollupFunction,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RollupDate {
+    pub date: Option<crate::object::page::date::PageDatePropertyParameter>,
+    pub function: RollupFunction,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RollupArray {
+    pub array: Vec<RollupArrayItem>,
+    pub function: RollupFunction,
+}
+
+/// An item in an array rollup.
+///
+/// Page responses contain property values, while property-item responses use
+/// empty placeholder objects.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum RollupArrayItem {
+    Property(crate::object::page::PageProperty),
+    Value(serde_json::Value),
+}
+
+/// A rollup value that Notion did not compute.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RollupUnsupported {
+    pub unsupported: std::collections::HashMap<(), ()>,
+    pub function: RollupFunction,
+}
+
+/// A partial rollup value returned while paginating property items.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RollupIncomplete {
+    pub incomplete: std::collections::HashMap<(), ()>,
+    pub function: RollupFunction,
+}
 
 #[cfg(test)]
 mod unit_tests {
     use super::*;
 
     #[test]
-    fn page_rollup_property() {
-        let json = r#"{"id":"ro1"}"#;
-        let prop: PageRollupProperty = serde_json::from_str(json).unwrap();
-        assert_eq!(prop.id.as_deref(), Some("ro1"));
-        assert_eq!(prop.to_string(), "");
+    fn deserialize_unsupported_rollup() {
+        let property: PageRollupProperty = serde_json::from_value(serde_json::json!({
+            "id": "rollup-id",
+            "rollup": {
+                "type": "unsupported",
+                "unsupported": {},
+                "function": "sum"
+            }
+        }))
+        .unwrap();
+
+        assert!(matches!(property.rollup, Rollup::Unsupported(_)));
+        assert_eq!(property.to_string(), "");
+    }
+
+    #[test]
+    fn deserialize_rollup_value_variants() {
+        let number: Rollup = serde_json::from_value(serde_json::json!({
+            "type": "number",
+            "number": 3.5,
+            "function": "average"
+        }))
+        .unwrap();
+        assert_eq!(number.to_string(), "3.5");
+
+        let date: Rollup = serde_json::from_value(serde_json::json!({
+            "type": "date",
+            "date": {
+                "start": "2026-08-05",
+                "end": null,
+                "time_zone": null
+            },
+            "function": "earliest_date"
+        }))
+        .unwrap();
+        assert_eq!(date.to_string(), "2026-08-05");
+
+        let incomplete: Rollup = serde_json::from_value(serde_json::json!({
+            "type": "incomplete",
+            "incomplete": {},
+            "function": "sum"
+        }))
+        .unwrap();
+        assert!(matches!(incomplete, Rollup::Incomplete(_)));
+
+        let array: Rollup = serde_json::from_value(serde_json::json!({
+            "type": "array",
+            "array": [
+                {
+                    "type": "relation",
+                    "relation": [{ "id": "page-id" }]
+                },
+                {}
+            ],
+            "function": "show_original"
+        }))
+        .unwrap();
+        assert!(matches!(array, Rollup::Array(_)));
     }
 }

--- a/notionrs_types/src/object/request/meeting_notes.rs
+++ b/notionrs_types/src/object/request/meeting_notes.rs
@@ -2,6 +2,99 @@ use serde::{Deserialize, Serialize};
 
 // # --------------------------------------------------------------------------------
 //
+// Create Meeting Note
+//
+// # --------------------------------------------------------------------------------
+
+/// The media source used to create a meeting note.
+///
+/// <https://developers.notion.com/reference/create-meeting-note>
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CreateMeetingNoteSource {
+    /// A completed public API file upload.
+    FileUpload {
+        /// ID of the completed file upload.
+        file_upload_id: String,
+    },
+    /// An existing audio, video, or file block.
+    Block {
+        /// ID of the existing block.
+        block_id: String,
+    },
+}
+
+impl CreateMeetingNoteSource {
+    /// Create a source from a completed public API file upload.
+    pub fn file_upload(file_upload_id: impl AsRef<str>) -> Self {
+        Self::FileUpload {
+            file_upload_id: file_upload_id.as_ref().to_owned(),
+        }
+    }
+
+    /// Create a source from an existing audio, video, or file block.
+    pub fn block(block_id: impl AsRef<str>) -> Self {
+        Self::Block {
+            block_id: block_id.as_ref().to_owned(),
+        }
+    }
+}
+
+/// Language hint for meeting note transcription.
+///
+/// <https://developers.notion.com/reference/create-meeting-note>
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreateMeetingNoteLanguage {
+    #[serde(rename = "auto")]
+    Auto,
+    #[serde(rename = "en")]
+    English,
+    #[serde(rename = "zh-CN")]
+    ChineseSimplified,
+    #[serde(rename = "zh-TW")]
+    ChineseTraditional,
+    #[serde(rename = "es")]
+    Spanish,
+    #[serde(rename = "fr")]
+    French,
+    #[serde(rename = "de")]
+    German,
+    #[serde(rename = "ja")]
+    Japanese,
+    #[serde(rename = "ko")]
+    Korean,
+    #[serde(rename = "pt")]
+    Portuguese,
+    #[serde(rename = "ru")]
+    Russian,
+    #[serde(rename = "th")]
+    Thai,
+    #[serde(rename = "vi")]
+    Vietnamese,
+    #[serde(rename = "id")]
+    Indonesian,
+    #[serde(rename = "da")]
+    Danish,
+    #[serde(rename = "fi")]
+    Finnish,
+    #[serde(rename = "no")]
+    Norwegian,
+    #[serde(rename = "nl")]
+    Dutch,
+    #[serde(rename = "it")]
+    Italian,
+    #[serde(rename = "sv")]
+    Swedish,
+    #[serde(rename = "ar")]
+    Arabic,
+    #[serde(rename = "he")]
+    Hebrew,
+    #[serde(rename = "pl")]
+    Polish,
+}
+
+// # --------------------------------------------------------------------------------
+//
 // Meeting Notes Filter
 //
 // # --------------------------------------------------------------------------------
@@ -261,6 +354,32 @@ pub enum MeetingNotesSortDirection {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+
+    #[test]
+    fn serialize_create_meeting_note_source_and_language() {
+        assert_eq!(
+            serde_json::to_value(CreateMeetingNoteSource::file_upload("upload-id")).unwrap(),
+            serde_json::json!({
+                "type": "file_upload",
+                "file_upload_id": "upload-id"
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(CreateMeetingNoteSource::block("block-id")).unwrap(),
+            serde_json::json!({
+                "type": "block",
+                "block_id": "block-id"
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(CreateMeetingNoteLanguage::ChineseSimplified).unwrap(),
+            "zh-CN"
+        );
+        assert_eq!(
+            serde_json::to_value(CreateMeetingNoteLanguage::Norwegian).unwrap(),
+            "no"
+        );
+    }
 
     #[test]
     fn serialize_combinator_filter() {

--- a/notionrs_types/src/prelude.rs
+++ b/notionrs_types/src/prelude.rs
@@ -1,6 +1,7 @@
 pub use crate::object::{
     block::{
-        Block, BlockResponse, MeetingNotesBlockResponse, QueryMeetingNotesResponse, bookmark::*,
+        Block, BlockResponse, CreateMeetingNoteResponse, MeetingNotesBlockResponse,
+        PartialMeetingNotesBlockResponse, QueryMeetingNotesResponse, bookmark::*,
         bulleted_list_item::*, callout::*, child_database::*, child_page::*, code::*, column::*,
         column_list::*, embed::*, equation::*, heading::*, link_preview::*, numbered_list_item::*,
         paragraph::*, quote::*, synced_block::*, tab::*, table::*, table_of_contents::*,


### PR DESCRIPTION
## Overview

Syncs `notionrs` with [`notion-sdk-js` v5.24.0](https://github.com/makenotion/notion-sdk-js/releases/tag/v5.24.0) and the current Notion API documentation.

## Related Issues

- Closes #658
- Closes #659

## Changes

- Add `Client::create_meeting_note()` for `POST /v1/blocks/meeting_notes`, including source-specific validation: file uploads require a parent page and existing blocks reject one.
- Add all documented transcription language values, full and ID-only create responses, and the `transcription_failed` processing status.
- Preserve the multipart file media type in `send_file_upload`, which is required when meeting-note media is declared as audio or video during file-upload creation.
- Add explicit `unsupported` formula and rollup values, including baseline rollup result modeling needed to expose the new variant.
- Recognize `invalid_beta` in both API errors and failed async-task errors. No `Notion-Beta` request forwarding was added because upstream v5.24.0 also leaves it out.
- Update three readonly multi-select filter tests to use the current `Something` fixture option instead of the removed `0` option.
- Bump `notionrs` to `0.31.0` and `notionrs_types` to `0.23.0` under the repository minor-version release policy.

### Breaking changes

- Exhaustive matches over `Formula`, `ApiErrorCode`, or `AsyncTaskErrorCode` must handle the new variants.
- `PageRollupProperty` now exposes its previously discarded `rollup` value, and `MeetingNotesBlockResponse` now exposes the required `type` field, so direct struct literals need updating.

### Testing

- `cargo check --workspace --all-targets`
- `cargo test --workspace --lib` (403 passed)
- `cargo test -p notionrs --test integration_test_mutable` (46 passed, 1 plan-gated test ignored)
- `cargo test -p notionrs --test integration_test_readonly` (102 passed, 4 ignored)
- The new meeting-note flow was attempted against the mutable workspace: media upload succeeded with `audio/wav`, then Notion returned its documented plan-entitlement error before creating a block. The integration test remains ignored until the workspace has AI meeting notes enabled.

## Checklist

- [x] The target branch for this PR is `main`.
- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] If you added new structs to `notionrs_types`, ensure you re-export the structs in the `prelude` module.
- [x] Documentation has been updated if necessary.
- [ ] Release tags have been added if needed.

## Additional Notes

- #660 tracks the pre-existing loss of `object`, `status`, and `additional_data` from failed async-task errors; it was kept out of this release sync.
- `cargo clippy --workspace` remains blocked by the pre-existing #629 described in `AGENTS.md`; workspace check and test commands were used instead.